### PR TITLE
vpr: Add make target for source code formatting

### DIFF
--- a/vpr/.clang-format
+++ b/vpr/.clang-format
@@ -1,0 +1,6 @@
+---
+Language: Cpp
+BasedOnStyle: Chromium
+IndentWidth: 4
+UseTab: ForIndentation
+SortIncludes: false

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -55,3 +55,14 @@ target_link_libraries(test_vpr
                         libvpr)
 
 add_test(NAME test_vpr COMMAND test_vpr --use-colour=yes)
+
+#
+# clang-format-5.0
+#
+
+add_custom_target(format-cpp
+	COMMAND find ${PROJECT_SOURCE_DIR}
+		-name '*.cpp' -print0 -name '*.h' -print0 |
+		xargs -0 -P `nproc` clang-format-5.0 -style=file -i)
+
+add_custom_target(format DEPENDS format-cpp)


### PR DESCRIPTION
This PR address 2 point from #13:
* Define clang-format rules for vtr C++
* Create target to automatically format the code