### PR TITLE
libblifparse: broaden allowed character set for Ids

### DIFF
--- a/libs/EXTERNAL/libblifparse/src/blif_lexer.l
+++ b/libs/EXTERNAL/libblifparse/src/blif_lexer.l
@@ -45,9 +45,7 @@
 %option prefix="blifparse_" 
 
 /* Common character classes */
-ALPHA_SYMBOLS [-a-zA-Z_~|:*/\[\]\.\{\}^+$;'"]
-DIGITS [0-9]
-ALPHA_NUM_SYMBOLS ({ALPHA_SYMBOLS}|{DIGITS})
+ID_SET [^ \t\r\n\\=]
 BACK_SLASH [\\]
 WS [ \t]
 ENDL (\n|\n\r|\r\n)
@@ -139,15 +137,7 @@ ENDL (\n|\n\r|\r\n)
                                   BEGIN(SO_COVER); 
                                   return blifparse::Parser::make_EOL(); 
                                 }
-<INITIAL,NAMES,LATCH>({DIGITS}({ALPHA_NUM_SYMBOLS}|{BACK_SLASH})*{ALPHA_NUM_SYMBOLS}+)|(({ALPHA_SYMBOLS}|{BACK_SLASH})*({ALPHA_NUM_SYMBOLS}|{BACK_SLASH})*{ALPHA_NUM_SYMBOLS}) {
-                                    /* The terrible regex above covers two cases:
-                                     *  1) An identifier starts with a digit, contains a combination of
-                                     *     alpha numeric and symbolic characters. To avoid conflicts with
-                                     *     line continuation, back slashes are forbidden in the last character.
-                                     *  2) An identifier with a non-numeric first letter (i.e. alpha, symbol, back slash)
-                                     *     followed by any number of (alpha, num, symbol, back slash) the last character
-                                     *     can be any alpha/num/symbol excluding back slashes (to avoid conflicts with line continuation)
-                                     */
+<INITIAL,NAMES,LATCH>(({ID_SET}|{BACK_SLASH})*{ID_SET}) {
                                     /*
                                      * We allow all sorts of characters in regular strings.
                                      * However we need to be careful about line continuations

--- a/libs/EXTERNAL/libblifparse/test/eblif/test.eblif
+++ b/libs/EXTERNAL/libblifparse/test/eblif/test.eblif
@@ -2,7 +2,10 @@
 .inputs a b clk
 .outputs o_dff
 
-.names a b a_and_b
+.names 1\a 3 a_-1234567890~|:*/\[\]\.\{\}^+$;'"?<>
+
+.names a b \
+  a_and_b
 11 1
 .cname lut_a_and_b
 


### PR DESCRIPTION
The set of characters was more restrictive than required. This was exposed by synth_ice40 in yosys passing -dress to the abc pass which resulted in _?_ appearing in some netnames.

