### PR TITLE
Handle some edge cases for FASM.

### DIFF
--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -1639,8 +1639,8 @@ static void ProcessMode(pugi::xml_node Parent, t_mode * mode,
 	map<string, int> pb_type_names;
 	pair<map<string, int>::iterator, bool> ret_pb_types;
 
-	if (0 == strcmp(Parent.name(), "pb_type")) {
-		/* implied mode */
+	bool implied_mode = 0 == strcmp(Parent.name(), "pb_type");
+	if (implied_mode) {
 		mode->name = vtr::strdup("default");
 	} else {
 		Prop = get_attribute(Parent, "name", loc_data).value();
@@ -1677,7 +1677,11 @@ static void ProcessMode(pugi::xml_node Parent, t_mode * mode,
 	/* Allocate power structure */
 	mode->mode_power = (t_mode_power*) vtr::calloc(1, sizeof(t_mode_power));
 
-	mode->meta = ProcessMetadata(Parent, loc_data);
+	if(!implied_mode) {
+		// Implied mode metadata is attached to the pb_type, rather than
+		// the t_mode object.
+		mode->meta = ProcessMetadata(Parent, loc_data);
+	}
 
 	/* Clear STL map used for duplicate checks */
 	pb_type_names.clear();

--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -108,17 +108,11 @@ void FasmWriterVisitor::check_interconnect(const t_pb_routes &pb_routes, int ino
   }
 }
 
-std::string FasmWriterVisitor::build_clb_prefix(const t_pb_graph_node* pb_graph_node) const {
-  std::string clb_prefix = "";
-
-  if(root_clb_ != pb_graph_node && pb_graph_node->parent_pb_graph_node != root_clb_) {
-    VTR_ASSERT(pb_graph_node->parent_pb_graph_node != nullptr);
-    clb_prefix = build_clb_prefix(pb_graph_node->parent_pb_graph_node);
-  }
-
-  const auto *pb_type = pb_graph_node->pb_type;
-  if(!pb_type->meta.has("fasm_prefix")) {
-    return clb_prefix;
+static std::string handle_fasm_prefix(const t_metadata_dict *meta,
+        const t_pb_graph_node *pb_graph_node, const t_pb_type *pb_type) {
+  bool has_prefix = meta != nullptr && meta->has("fasm_prefix");
+  if(!has_prefix) {
+      return "";
   }
 
   auto fasm_prefix_unsplit = pb_type->meta.one("fasm_prefix")->as_string();
@@ -138,8 +132,51 @@ std::string FasmWriterVisitor::build_clb_prefix(const t_pb_graph_node* pb_graph_
               fasm_prefix_unsplit.c_str(), pb_type->num_pb);
   }
 
-  return clb_prefix + fasm_prefix.at(pb_graph_node->placement_index) + ".";
+  return fasm_prefix.at(pb_graph_node->placement_index) + ".";
+}
 
+std::string FasmWriterVisitor::build_clb_prefix(const t_pb *pb, const t_pb_graph_node* pb_graph_node) const {
+  std::string clb_prefix = "";
+
+  const t_pb *pb_for_graph_node = nullptr;
+
+  // If not t_pb, mode_index is always 0.
+  int mode_index = 0;
+  if(root_clb_ != pb_graph_node && pb_graph_node->parent_pb_graph_node != root_clb_) {
+    VTR_ASSERT(pb_graph_node->parent_pb_graph_node != nullptr);
+    if(pb != nullptr) {
+        while(pb_for_graph_node == nullptr) {
+            pb_for_graph_node = pb->find_pb(pb_graph_node);
+            if(pb_for_graph_node == nullptr) {
+                if(pb->parent_pb == nullptr) {
+                    break;
+                }
+                pb = pb->parent_pb;
+            }
+        }
+
+        if(pb_for_graph_node != nullptr) {
+            mode_index = pb_for_graph_node->mode;
+        }
+    }
+
+    clb_prefix = build_clb_prefix(pb, pb_graph_node->parent_pb_graph_node);
+  }
+
+  const auto *pb_type = pb_graph_node->pb_type;
+
+  clb_prefix += handle_fasm_prefix(&pb_type->meta, pb_graph_node, pb_type);
+
+  if(pb_type->modes != nullptr) {
+    VTR_ASSERT(mode_index < pb_type->num_modes);
+
+    clb_prefix += handle_fasm_prefix(&pb_type->modes[mode_index].meta,
+            pb_graph_node, pb_type);
+  } else {
+      VTR_ASSERT(mode_index == 0);
+  }
+
+  return clb_prefix;
 }
 
 static const t_pb_graph_pin* is_node_used(const t_pb_routes &top_pb_route, const t_pb_graph_node* pb_graph_node) {
@@ -182,7 +219,7 @@ void FasmWriterVisitor::visit_all_impl(const t_pb_routes &pb_routes, const t_pb*
 
   const t_pb_graph_node *pb_graph_node = pb->pb_graph_node;
 
-  clb_prefix_ = build_clb_prefix(pb_graph_node);
+  clb_prefix_ = build_clb_prefix(pb, pb_graph_node);
 
   t_pb_type *pb_type = pb_graph_node->pb_type;
   auto *mode = &pb_type->modes[pb->mode];
@@ -193,15 +230,15 @@ void FasmWriterVisitor::visit_all_impl(const t_pb_routes &pb_routes, const t_pb*
   }
 
   if(mode != nullptr && std::string(mode->name) == "wire") {
-      auto io_pin = is_node_used(pb_routes, pb_graph_node);
-      if(io_pin != nullptr) {
-        const auto& route = pb_routes.at(io_pin->pin_count_in_cluster);
-        const int num_inputs = *route.pb_graph_pin->parent_node->num_input_pins;
-        const auto *lut_definition = find_lut(route.pb_graph_pin->parent_node);
-        VTR_ASSERT(lut_definition->num_inputs == num_inputs);
+    auto io_pin = is_node_used(pb_routes, pb_graph_node);
+    if(io_pin != nullptr) {
+    const auto& route = pb_routes.at(io_pin->pin_count_in_cluster);
+      const int num_inputs = *route.pb_graph_pin->parent_node->num_input_pins;
+      const auto *lut_definition = find_lut(route.pb_graph_pin->parent_node);
+      VTR_ASSERT(lut_definition->num_inputs == num_inputs);
 
-        output_fasm_features(lut_definition->CreateWire(route.pb_graph_pin->pin_number));
-      }
+      output_fasm_features(lut_definition->CreateWire(route.pb_graph_pin->pin_number));
+    }
   }
 
   int port_index = 0;
@@ -215,6 +252,19 @@ void FasmWriterVisitor::visit_all_impl(const t_pb_routes &pb_routes, const t_pb*
     }
     port_index += 1;
   }
+
+  port_index = 0;
+  for (int i = 0; i < pb_type->num_ports; i++) {
+    if (!pb_type->ports[i].is_clock || pb_type->ports[i].type != IN_PORT) {
+      continue;
+    }
+    for (int j = 0; j < pb_type->ports[i].num_pins; j++) {
+      int inode = pb->pb_graph_node->clock_pins[port_index][j].pin_count_in_cluster;
+      check_interconnect(pb_routes, inode);
+    }
+    port_index += 1;
+  }
+
   port_index = 0;
   for (int i = 0; i < pb_type->num_ports; i++) {
     if (pb_type->ports[i].type != OUT_PORT) {

--- a/utils/fasm/src/fasm.h
+++ b/utils/fasm/src/fasm.h
@@ -71,7 +71,7 @@ class FasmWriterVisitor : public NetlistVisitor {
       void check_for_lut(const t_pb* atom);
       void output_fasm_mux(std::string fasm_mux, t_interconnect *interconnect, t_pb_graph_pin *mux_input_pin);
       void walk_routing();
-      std::string build_clb_prefix(const t_pb_graph_node* pb_graph_node) const;
+      std::string build_clb_prefix(const t_pb *pb, const t_pb_graph_node* pb_graph_node) const;
       const LutOutputDefinition* find_lut(const t_pb_graph_node* pb_graph_node);
       void check_for_param(const t_pb *atom);
 


### PR DESCRIPTION
Two edge cases for FASM output were missed during the initial implementation:
 - Using "fasm_prefix" on `<mode>` tags now works as expected
 - Using "fasm_mux" on interconnect connected to `<clock>` tags now works as expected.

Plan is to create test cases and merge upstream *after* https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/510 is merged upstream and merged on downstream fork.