### PR TITLE
Avoid duplicate work during flow.

### DIFF
--- a/vpr/src/base/read_route.cpp
+++ b/vpr/src/base/read_route.cpp
@@ -122,10 +122,6 @@ bool read_route(const char* route_file, const t_router_opts& router_opts, bool v
     /* Finished loading in the routing, now check it*/
 	recompute_occupancy_from_scratch();
     bool is_feasible = feasible_routing();
-    if (is_feasible) {
-        check_route(router_opts.route_type);
-    }
-    get_serial_num();
 
     VTR_LOG("Finished loading route file\n");
 

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -776,9 +776,6 @@ RouteStatus vpr_load_routing(t_vpr_setup& vpr_setup, const t_arch& arch, int fix
         VPR_THROW(VPR_ERROR_ROUTE, "Fixed channel width must be specified when loading routing (was %d)", fixed_channel_width);
     }
 
-    //Create the routing resource graph
-    vpr_create_rr_graph(vpr_setup, arch, fixed_channel_width);
-
     auto& filename_opts = vpr_setup.FileNameOpts;
 
     //Load the routing from a file


### PR DESCRIPTION
This PR has been sent upstream, this makes the change downstream.