### PR TITLE
Fix handling of fasm_lut directives at level outside of ".names".

### DIFF
--- a/doc/src/utils/fasm.rst
+++ b/doc/src/utils/fasm.rst
@@ -148,6 +148,11 @@ example:
      </meta>
    </metadata>
 
+FASM LUT metadata must be attached to the ``<pb_type>`` at or directly above
+the ``<pb_type>`` with ``blif_model=".names"``.  The FASM LUT metadata tags
+will not be recognized attached inside of ``<mode>`` tags or inside
+``<pb_type>``'s higher than 1 level above the leaf type.
+
 When specifying a FASM features with more than one bit, explicitly specify the
 bit range being set.  This is required because "genfasm" does not have access
 to the actual bit database, and would otherwise not have the width of the

--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -374,14 +374,17 @@ static const t_metadata_dict *get_fasm_type(const t_pb_graph_node* pb_graph_node
     return nullptr;
   }
 
-  t_metadata_dict *meta = nullptr;
+  const t_metadata_dict *meta = nullptr;
   if(pb_graph_node->pb_type->meta.has("fasm_type")) {
     meta = &pb_graph_node->pb_type->meta;
   }
 
-  if(pb_graph_node->pb_type->parent_mode != nullptr &&
-     pb_graph_node->pb_type->parent_mode->meta.has("fasm_type")) {
-    meta = &pb_graph_node->pb_type->parent_mode->meta;
+  if(pb_graph_node->pb_type->parent_mode != nullptr) {
+    VTR_ASSERT(pb_graph_node->pb_type->parent_mode->parent_pb_type != nullptr);
+    const t_pb_type *pb_type = pb_graph_node->pb_type->parent_mode->parent_pb_type;
+    if(pb_type->meta.has("fasm_type")) {
+      meta = &pb_type->meta;
+    }
   }
 
   if(meta != nullptr && meta->one("fasm_type")->as_string() == target_type) {

--- a/utils/fasm/test/test_fasm_arch.xml
+++ b/utils/fasm/test/test_fasm_arch.xml
@@ -122,12 +122,6 @@
                   235e-12
                   235e-12
                 </delay_matrix>
-                <metadata>
-                  <meta name="fasm_type">LUT</meta>
-                  <meta name="fasm_lut">
-                    LUT[31:0] = LUT
-                  </meta>
-                </metadata>
               </pb_type>
 
               <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
@@ -156,6 +150,10 @@
                 </mux>
               </interconnect>
               <metadata>
+                <meta name="fasm_type">LUT</meta>
+                <meta name="fasm_lut">
+                  LUT[31:0]
+                </meta>
                 <meta name="fasm_prefix">
                   LUT5_0 LUT5_1
                 </meta>
@@ -199,7 +197,7 @@
               <metadata>
                 <meta name="fasm_type">LUT</meta>
                 <meta name="fasm_lut">
-                  LUT6[63:0] = LUT
+                  LUT6[63:0]
                 </meta>
               </metadata>
             </pb_type>


### PR DESCRIPTION
Add's test case for both usages of fasm_lut.