### PR TITLE
Reset illegal_modes prior to attempting cluster routing.

### DIFF
--- a/vpr/src/pack/cluster.cpp
+++ b/vpr/src/pack/cluster.cpp
@@ -639,6 +639,7 @@ std::map<t_type_ptr,size_t> do_clustering(const t_packer_opts& packer_opts, cons
 			if (detailed_routing_stage == (int)E_DETAILED_ROUTE_AT_END_ONLY) {
 				// FIXME: is_mode_conflict does not affect this stage. It will be needed when trying to route the packed clusters later on.
 				bool is_mode_conflict;
+				reset_intra_lb_route(router_data);
 				is_cluster_legal = try_intra_lb_route(router_data, packer_opts.pack_verbosity, &is_mode_conflict);
 				if (is_cluster_legal == true) {
                     VTR_LOGV(packer_opts.pack_verbosity > 2, "\tPassed route at end.\n");
@@ -1217,6 +1218,7 @@ static enum e_block_pack_status try_pack_molecule(
 				bool is_mode_conflict = true;
 				bool is_routed = false;
 				bool do_detailed_routing_stage = detailed_routing_stage == (int)E_DETAILED_ROUTE_FOR_EACH_ATOM;
+				reset_intra_lb_route(router_data);
 				while (do_detailed_routing_stage && is_mode_conflict) {
 					is_routed = try_intra_lb_route(router_data, verbosity, &is_mode_conflict);
 				}

--- a/vpr/src/pack/cluster_router.cpp
+++ b/vpr/src/pack/cluster_router.cpp
@@ -1479,3 +1479,14 @@ static std::string describe_congested_rr_nodes(const std::vector<int>& congested
 
     return description;
 }
+
+void reset_intra_lb_route(t_lb_router_data *router_data) {
+    for(auto &node : *router_data->lb_type_graph) {
+        auto *pin = node.pb_graph_pin;
+        if(pin == nullptr) {
+            continue;
+        }
+        VTR_ASSERT(pin->parent_node != nullptr);
+        pin->parent_node->illegal_modes.clear();
+    }
+}

--- a/vpr/src/pack/cluster_router.h
+++ b/vpr/src/pack/cluster_router.h
@@ -20,6 +20,7 @@ void add_atom_as_target(t_lb_router_data *router_data, const AtomBlockId blk_id)
 void remove_atom_from_target(t_lb_router_data *router_data, const AtomBlockId blk_id);
 void set_reset_pb_modes(t_lb_router_data *router_data, const t_pb *pb, const bool set);
 bool try_intra_lb_route(t_lb_router_data *router_data, int verbosity, bool *is_mode_conflict);
+void reset_intra_lb_route(t_lb_router_data *router_data);
 
 /* Accessor Functions */
 t_pb_routes alloc_and_load_pb_route(const vector <t_intra_lb_net> *intra_lb_nets, t_pb_graph_node *pb_graph_head);


### PR DESCRIPTION
This fixes an intermittent issues I've been seeing around LUT-RAM packing failing.  I believe I traced it the illegal_modes state being stale between iterations of the packer.