### PR TITLE
Enable PugiXML compact mode

### DIFF
--- a/libs/EXTERNAL/libpugixml/CMakeLists.txt
+++ b/libs/EXTERNAL/libpugixml/CMakeLists.txt
@@ -19,4 +19,7 @@ set_target_properties(libpugixml PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
 set(PUGIXML_SUPPRESS_FLAGS -w)
 target_compile_options(libpugixml PRIVATE ${PUGIXML_SUPPRESS_FLAGS})
 
+#Enable compact mode which reduces memory usage.
+add_definitions(-DPUGIXML_COMPACT)
+
 install(TARGETS libpugixml DESTINATION bin)


### PR DESCRIPTION
This enables PugiXML's [compact mode](https://pugixml.org/docs/manual.html#dom.memory.compact) as discussed in #34. To quote the benchmark from #34:

>Create Device times:
>
>| Reader | Time to create device(5 runs) | max_rss to create device |
>|------------|-----------------------------------------|---------------------------|
>|PugiXML|`21.78 21.68 21.9 21.71 21.99`|5902.4 MiB|
>|PugiXML compact|`25.17 24.63 24.43 24.59 24.16`|3200.3 MiB|
>|LibXML2 SAX|`31.31 30.96 30.83 30.99 30.85`|1895.5 MiB|

#### Description
This is a one-line PR which adds `-DPUGIXML_COMPACT` to PugiXML's compilation options. 

#### Related Issue
#34, [symbiflow-arch-defs/#686](https://github.com/SymbiFlow/symbiflow-arch-defs/issues/686) 

#### Motivation and Context
If not in compact mode, PugiXML's DOM API allocates at least 2x the XML file's size in memory. Enabling compact mode is an easy change and reduces memory usage by 45% while increasing running time by 15%.

I tried to enable it only for the rr_graph reader, but then decided it isn't worth it, because
1. the other XML readers run in negligible time compared to the rr_graph reader
2. libpugixml is compiled as a static library, so enabling compact mode only for the rr_graph reader would require cmake changes and slow down the build.

#### How Has This Been Tested?
The benchmark is run in a LXC container, against VPR `8.0.0-dev+vpr-7.0.5-6722-ga5e0a0ad4` and #34.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
