### PR TITLE
Allow 1:N mapping of eblif parameters to fasm features

### DIFF
--- a/utils/fasm/src/parameters.h
+++ b/utils/fasm/src/parameters.h
@@ -20,7 +20,7 @@ class Parameters {
       std::string feature;
   };
 
-  std::unordered_map<std::string, FeatureParameter> features_;
+  std::unordered_multimap<std::string, FeatureParameter> features_;
 
   size_t FeatureWidth(const std::string &feature) const;
 };


### PR DESCRIPTION
Needed to support fasm parameter for xc7 RAMB36E1.