### PR TITLE
utils/fasm: Fix segfault in handle_fasm_prefix.

### DIFF
--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -116,7 +116,7 @@ static std::string handle_fasm_prefix(const t_metadata_dict *meta,
       return "";
   }
 
-  auto fasm_prefix_unsplit = pb_type->meta.one("fasm_prefix")->as_string();
+  auto fasm_prefix_unsplit = meta->one("fasm_prefix")->as_string();
   auto fasm_prefix = vtr::split(fasm_prefix_unsplit, " \t\n");
   VTR_ASSERT(pb_type->num_pb >= 0);
   if(fasm_prefix.size() != static_cast<size_t>(pb_type->num_pb)) {


### PR DESCRIPTION
Previously it would check the metadata dictionary for `fasm_prefix` and then use the metadata on the pb_type. This fails in the case where `handle_fasm_prefix` is called on a mode like below;
```cpp
 handle_fasm_prefix(&pb_type->modes[mode_index].meta, pb_graph_node, pb_type);
```