### PR TITLE
fasm.cpp: return from visit if pb is `open`

### DIFF
--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -136,7 +136,7 @@ static std::string handle_fasm_prefix(const t_metadata_dict *meta,
   return fasm_prefix.at(pb_graph_node->placement_index) + ".";
 }
 
-std::string FasmWriterVisitor::build_clb_prefix(const t_pb *pb, const t_pb_graph_node* pb_graph_node) const {
+std::string FasmWriterVisitor::build_clb_prefix(const t_pb *pb, const t_pb_graph_node* pb_graph_node, bool* is_parent_pb_null) const {
   std::string clb_prefix = "";
 
   const t_pb *pb_for_graph_node = nullptr;
@@ -146,22 +146,24 @@ std::string FasmWriterVisitor::build_clb_prefix(const t_pb *pb, const t_pb_graph
   if(root_clb_ != pb_graph_node && pb_graph_node->parent_pb_graph_node != root_clb_) {
     VTR_ASSERT(pb_graph_node->parent_pb_graph_node != nullptr);
     if(pb != nullptr) {
-        while(pb_for_graph_node == nullptr) {
-            pb_for_graph_node = pb->find_pb(pb_graph_node);
-            if(pb_for_graph_node == nullptr) {
-                if(pb->parent_pb == nullptr) {
-                    break;
-                }
-                pb = pb->parent_pb;
-            }
-        }
+      while(pb_for_graph_node == nullptr) {
+        pb_for_graph_node = pb->find_pb(pb_graph_node);
 
-        if(pb_for_graph_node != nullptr) {
-            mode_index = pb_for_graph_node->mode;
+        if(pb_for_graph_node == nullptr) {
+          if(pb->parent_pb == nullptr) {
+            *is_parent_pb_null = true;
+            break;
+          }
+          pb = pb->parent_pb;
         }
+      }
+
+      if(pb_for_graph_node != nullptr) {
+        mode_index = pb_for_graph_node->mode;
+      }
     }
 
-    clb_prefix = build_clb_prefix(pb, pb_graph_node->parent_pb_graph_node);
+    clb_prefix = build_clb_prefix(pb, pb_graph_node->parent_pb_graph_node, is_parent_pb_null);
   }
 
   const auto *pb_type = pb_graph_node->pb_type;
@@ -172,9 +174,9 @@ std::string FasmWriterVisitor::build_clb_prefix(const t_pb *pb, const t_pb_graph
     VTR_ASSERT(mode_index < pb_type->num_modes);
 
     clb_prefix += handle_fasm_prefix(&pb_type->modes[mode_index].meta,
-            pb_graph_node, pb_type);
+                                     pb_graph_node, pb_type);
   } else {
-      VTR_ASSERT(mode_index == 0);
+    VTR_ASSERT(mode_index == 0);
   }
 
   return clb_prefix;
@@ -220,7 +222,13 @@ void FasmWriterVisitor::visit_all_impl(const t_pb_routes &pb_routes, const t_pb*
 
   const t_pb_graph_node *pb_graph_node = pb->pb_graph_node;
 
-  clb_prefix_ = build_clb_prefix(pb, pb_graph_node);
+  // Check if this PB is `open` and has to be skipped
+  bool is_parent_pb_null = false;
+  std::string clb_prefix = build_clb_prefix(pb, pb_graph_node, &is_parent_pb_null);
+  if (is_parent_pb_null == true) {
+    return;
+  }
+  clb_prefix_ = clb_prefix;
 
   t_pb_type *pb_type = pb_graph_node->pb_type;
   auto *mode = &pb_type->modes[pb->mode];
@@ -233,7 +241,7 @@ void FasmWriterVisitor::visit_all_impl(const t_pb_routes &pb_routes, const t_pb*
   if(mode != nullptr && std::string(mode->name) == "wire") {
     auto io_pin = is_node_used(pb_routes, pb_graph_node);
     if(io_pin != nullptr) {
-    const auto& route = pb_routes.at(io_pin->pin_count_in_cluster);
+      const auto& route = pb_routes.at(io_pin->pin_count_in_cluster);
       const int num_inputs = *route.pb_graph_pin->parent_node->num_input_pins;
       const auto *lut_definition = find_lut(route.pb_graph_pin->parent_node);
       VTR_ASSERT(lut_definition->num_inputs == num_inputs);

--- a/utils/fasm/src/fasm.h
+++ b/utils/fasm/src/fasm.h
@@ -73,7 +73,7 @@ class FasmWriterVisitor : public NetlistVisitor {
       void output_fasm_mux(std::string fasm_mux, t_interconnect *interconnect, t_pb_graph_pin *mux_input_pin);
       void walk_routing();
       void walk_route_tree(const t_rt_node *root);
-      std::string build_clb_prefix(const t_pb *pb, const t_pb_graph_node* pb_graph_node) const;
+      std::string build_clb_prefix(const t_pb *pb, const t_pb_graph_node* pb_graph_node, bool* is_parent_pb_null) const;
       const LutOutputDefinition* find_lut(const t_pb_graph_node* pb_graph_node);
       void check_for_param(const t_pb *atom);
 


### PR DESCRIPTION
This change avoids the net visitor to write fasm outputs of pb_graph_nodes which do not have valid corresponding PBs and valid parent PBs (this could suggest that the PB is actually `open`).

These PBs are skipped and the visit goes on to the next PB in the net.

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>