### PR TITLE
[DNM] Add support for multiple FASM features for a single mux selection.

### DIFF
--- a/doc/src/utils/fasm.rst
+++ b/doc/src/utils/fasm.rst
@@ -233,6 +233,20 @@ can also be used with the ``<direct>`` tag in the same way, example:
       </metadata>
     </direct>
 
+If multiple FASM features are required for a mux, they can be specified using
+comma's as a seperator.  Example:
+
+.. code-block:: xml
+
+    <mux name="D5FFMUX" input="BLK_IG-COMMON_SLICE.DX BLK_IG-COMMON_SLICE.DO5" output="BLK_BB-SLICE_FF.D5[3]" >
+      <metadata>
+        <meta name="fasm_mux">
+          BLK_IG-COMMON_SLICE.DO5 : D5FFMUX.IN_A
+          BLK_IG-COMMON_SLICE.DX : D5FFMUX.IN_B, D5FF.OTHER_FEATURE
+        </meta>
+      </metadata>
+    </mux>
+
 Passing parameters through to the FASM Output
 ---------------------------------------------
 

--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -658,12 +658,14 @@ void FasmWriterVisitor::output_fasm_mux(std::string fasm_mux,
       bool root_level_connection = interconnect->parent_mode->parent_pb_type ==
           mux_input_pin->parent_node->pb_type;
 
+      auto fasm_features = vtr::join(vtr::split(mux_parts[1], ","), "\n");
+
       if(root_level_connection) {
         // This connection is root level.  pb_index selects between
         // pb_type_prefixes_, not on the mux input.
         if(mux_pb_name == pb_name && mux_port_name == port_name && mux_pin_index == pin_index) {
           if(mux_parts[1] != "NULL") {
-            output_fasm_features(mux_parts[1]);
+            output_fasm_features(fasm_features);
           }
           return;
         }
@@ -672,7 +674,7 @@ void FasmWriterVisitor::output_fasm_mux(std::string fasm_mux,
                 mux_port_name == port_name &&
                 mux_pin_index == pin_index) {
         if(mux_parts[1] != "NULL") {
-          output_fasm_features(mux_parts[1]);
+          output_fasm_features(fasm_features);
         }
         return;
       }

--- a/utils/fasm/test/test_fasm.cpp
+++ b/utils/fasm/test/test_fasm.cpp
@@ -81,11 +81,14 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
     std::set<std::tuple<int, int, short>> routing_edges;
     bool found_lut5 = false;
     bool found_lut6 = false;
+    bool found_mux1 = false;
+    bool found_mux2 = false;
     while(fasm_string) {
         // Should see something like:
         // CLB.FLE0.N2_LUT5
         // CLB.FLE8.LUT5_1.LUT[31:0]=32'b00000000000000010000000000000000
         // CLB.FLE9.OUT_MUX.LUT
+        // CLB.FLE9.DISABLE_FF
         // CLB.FLE9.LUT6[63:0]=64'b0000000000000000000000000000000100000000000000000000000000000000
         // 3634_3690_0
         std::string line;
@@ -93,6 +96,13 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
 
         if(line == "") {
             continue;
+        }
+
+        if(!found_mux1 && line == "CLB.FLE9.OUT_MUX.LUT") {
+            found_mux1 = true;
+        }
+        if(!found_mux2 && line == "CLB.FLE9.DISABLE_FF") {
+            found_mux2 = true;
         }
 
         if(line.find("CLB") != std::string::npos) {
@@ -138,6 +148,8 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
 
     CHECK(found_lut5);
     CHECK(found_lut6);
+    CHECK(found_mux1);
+    CHECK(found_mux2);
 
     vpr_free_all(arch, vpr_setup);
 }

--- a/utils/fasm/test/test_fasm_arch.xml
+++ b/utils/fasm/test/test_fasm_arch.xml
@@ -145,7 +145,7 @@
                   <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble5.out[0:0]"/>
                   <meta name="fasm_mux">
                     ff.Q : OUT_MUX.FFQ
-                    lut5.out : OUT_MUX.LUT
+                    lut5.out : OUT_MUX.LUT,DISABLE_FF
                   </meta>
                 </mux>
               </interconnect>
@@ -223,7 +223,7 @@
                 <metadata>
                   <meta name="fasm_mux">
                     ff.Q : OUT_MUX.FFQ
-                    lut6.out : OUT_MUX.LUT
+                    lut6.out : OUT_MUX.LUT,DISABLE_FF
                   </meta>
                 </metadata>
               </mux>


### PR DESCRIPTION
#### Description

Previously only one FASM feature could be specified per mux selection.  In some cases, it is convenient to specify multiple features.  This PR enables multiple features to be specified, while being backwards compatible with the previous syntax.

#### Motivation and Context

The case that motives this change is using features in "passthrough".  There are couple examples of this in the 7-series arch.  The first is the "BUFHCE" pass-through.    This requires two features:
```
BUFHCE_X0Y0.IN_USE
BUFHCE_X0Y0.ZINV_CE
```

So if the BUFHCE is in passthrough, both features must be set.  No additional routing is required in this case because by default the pin CE == 1, and by default the inverted on the CE IPIN is enabled, e.g. held in reset.  These two features enable the use of a particular BUFHCE (e.g. connecting the input  clock to the horizontial clock network).

The other example is using the FF in a SLICEL as a passthrough, which requires:
```
AFF.ZRST
AFF.ZINI
LATCH
CLKINV
```

#### How Has This Been Tested?

A unit test has been written and testing has been down with symbiflow integration cases.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
