### PR TITLE
 VPR binary rr_node and rr_edge read/write

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/vtr-change.md
+++ b/.github/ISSUE_TEMPLATE/vtr-change.md
@@ -1,0 +1,25 @@
+---
+name: VTR change
+about: Describe purpose and lifecycle of a local change we made to VTR
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Why did we need this? (what does this change enable us to do)
+<!--- i.e. what does this change enable us to do? -->
+
+### What did it change?
+<!--- i.e. technical description what the change does -->
+
+### Should it be merged upstream - if not, when can we delete it?
+
+### What is needed to get this merged / deleted? 
+
+* [ ] is the implementation work to make suitable for merging / deletion completed?
+* [ ] Is there an associated test? <!--- i.e. how will we prevent it from regressing? -->
+* [ ] is this currently part of the Conda package?
+* [ ] is this properly cleaned up in our local repositories? <!--- add subtasks here if needed) -->
+
+### Tracker / branch / PR & other useful links

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
+
+SymbiFlow WIP changes for Verilog to Routing (VTR)
+==================================================
+
+This branch contains work in progress changes for using Verilog to Routing
+(VTR) as part of SymbiFlow.
+
+---
+
 # Verilog to Routing (VTR)
-[![Build Status](https://travis-ci.org/verilog-to-routing/vtr-verilog-to-routing.svg?branch=master)](https://travis-ci.org/verilog-to-routing/vtr-verilog-to-routing) [![Documentation Status](https://readthedocs.org/projects/vtr/badge/?version=latest)](http://docs.verilogtorouting.org/en/latest/?badge=latest)
+[![Build Status](https://travis-ci.com/SymbiFlow/vtr-verilog-to-routing.svg?branch=master)](https://travis-ci.com/SymbiFlow/vtr-verilog-to-routing) [![Documentation Status](https://readthedocs.org/projects/vtr/badge/?version=latest)](http://docs.verilogtorouting.org/en/latest/?badge=latest)
 
 ## Introduction
 The Verilog-to-Routing (VTR) project is a world-wide collaborative effort to provide a open-source framework for conducting FPGA architecture and CAD research and development.

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -1225,6 +1225,7 @@ enum class BufferSize {
  * R:  Equivalent resistance of the buffer/switch.                           *
  * Cin:  Input capacitance.                                                  *
  * Cout:  Output capacitance.                                                *
+ * Cinternal: Internal capacitance in a buffer with fanout.                  *
  * Tdel_map: A map where the key is the number of inputs and the entry       *
  *           is the corresponding delay. If there is only one entry at key   *
  *           UNDEFINED, then delay is a constant (doesn't vary with fan-in). *
@@ -1242,6 +1243,7 @@ struct t_arch_switch_inf {
     float R = 0.;
     float Cin = 0.;
     float Cout = 0.;
+    float Cinternal = 0.; // defined the property Cinternal
     float mux_trans_size = 1.;
     BufferSize buf_size_type = BufferSize::AUTO;
     float buf_size = 0.;
@@ -1293,6 +1295,7 @@ struct t_arch_switch_inf {
  * R:  Equivalent resistance of the buffer/switch.                           *
  * Cin:  Input capacitance.                                                  *
  * Cout:  Output capacitance.                                                *
+ * Cinternal: Internal capacitance in a buffer.                              *
  * Tdel:  Intrinsic delay.  The delay through an unloaded switch is          *
  *        Tdel + R * Cout.                                                   *
  * mux_trans_size:  The area of each transistor in the segment's driving mux *
@@ -1303,6 +1306,7 @@ struct t_rr_switch_inf {
     float R = 0.;
     float Cin = 0.;
     float Cout = 0.;
+    float Cinternal = 0.; //defined the property Cinternal
     float Tdel = 0.;
     float mux_trans_size = 0.;
     float buf_size = 0.;

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -3074,23 +3074,23 @@ static void ProcessSwitches(pugi::xml_node Parent,
         SwitchType type = SwitchType::MUX;
         if (0 == strcmp(type_name, "mux")) {
             type = SwitchType::MUX;
-            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel", "buf_size", "power_buf_size", "mux_trans_size"}, " with type '"s + type_name + "'"s, loc_data);
+            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Cinternal", "Tdel", "buf_size", "power_buf_size", "mux_trans_size"}, " with type '"s + type_name + "'"s, loc_data); // buffered switch should have a Cinternal element
 
         } else if (0 == strcmp(type_name, "tristate")) {
             type = SwitchType::TRISTATE;
-            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel", "buf_size", "power_buf_size"}, " with type '"s + type_name + "'"s, loc_data);
+            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Cinternal", "Tdel", "buf_size", "power_buf_size"}, " with type '"s + type_name + "'"s, loc_data); // buffered switch should have a Cinternal element
 
         } else if (0 == strcmp(type_name, "buffer")) {
             type = SwitchType::BUFFER;
-            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel", "buf_size", "power_buf_size"}, " with type '"s + type_name + "'"s, loc_data);
+            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel", "buf_size", "power_buf_size"}, " with type '"s + type_name + "'"s, loc_data); // buffer should not have a Cinternal element
 
         } else if (0 == strcmp(type_name, "pass_gate")) {
             type = SwitchType::PASS_GATE;
-            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel"}, " with type '"s + type_name + "'"s, loc_data);
+            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel"}, " with type '"s + type_name + "'"s, loc_data); // unbuffered switch does not have Cinternal element
 
         } else if (0 == strcmp(type_name, "short")) {
             type = SwitchType::SHORT;
-            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel"}, " with type "s + type_name + "'"s, loc_data);
+            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel"}, " with type "s + type_name + "'"s, loc_data); // unbuffered switch does not have Cinternal element
 
         } else {
             archfpga_throw(loc_data.filename_c_str(), loc_data.line(Node),
@@ -3102,6 +3102,8 @@ static void ProcessSwitches(pugi::xml_node Parent,
 
         ReqOpt COUT_REQD = TIMING_ENABLE_REQD;
         ReqOpt CIN_REQD = TIMING_ENABLE_REQD;
+        ReqOpt CINTERNAL_REQD = OPTIONAL; //defined the parameter
+
         if (arch_switch.type() == SwitchType::SHORT) {
             //Cin/Cout are optional on shorts, since they really only have one capacitance
             CIN_REQD = OPTIONAL;
@@ -3109,6 +3111,7 @@ static void ProcessSwitches(pugi::xml_node Parent,
         }
         arch_switch.Cin = get_attribute(Node, "Cin", loc_data, CIN_REQD).as_float(0);
         arch_switch.Cout = get_attribute(Node, "Cout", loc_data, COUT_REQD).as_float(0);
+        arch_switch.Cinternal = get_attribute(Node, "Cinternal", loc_data, CINTERNAL_REQD).as_float(0); // retrieve the optional parameter
 
         if (arch_switch.type() == SwitchType::MUX) {
             //Only muxes have mux transistors

--- a/libs/libvtrutil/src/vtr_log.cpp
+++ b/libs/libvtrutil/src/vtr_log.cpp
@@ -1,5 +1,9 @@
-#include "vtr_log.h"
+#include <string>
+#include <fstream>
+#include <cstdarg>
 
+#include "vtr_util.h"
+#include "vtr_log.h"
 #include "log.h"
 
 namespace vtr {
@@ -14,3 +18,33 @@ void set_log_file(const char* filename) {
 }
 
 } // namespace vtr
+
+void add_warnings_to_suppress(std::string function_name) {
+    warnings_to_suppress.insert(function_name);
+}
+
+void set_noisy_warn_log_file(const char* log_file_name) {
+    std::ofstream log;
+    log.open(log_file_name, std::ifstream::out | std::ifstream::trunc);
+    log.close();
+    noisy_warn_log_file = std::string(log_file_name);
+}
+
+void suppress_warning(const char* pszFileName, unsigned int lineNum, const char* pszFuncName, const char* pszMessage, ...) {
+    std::string function_name(pszFuncName);
+
+    va_list va_args;
+    va_start(va_args, pszMessage);
+    std::string msg = vtr::vstring_fmt(pszMessage, va_args);
+    va_end(va_args);
+
+    auto result = warnings_to_suppress.find(function_name);
+    if (result == warnings_to_suppress.end()) {
+        vtr::printf_warning(pszFileName, lineNum, msg.data());
+    } else {
+        std::ofstream log;
+        log.open(noisy_warn_log_file.data(), std::ios_base::app);
+        log << "Warning:\n\tfile: " << pszFileName << "\n\tline: " << lineNum << "\n\tmessage: " << msg << std::endl;
+        log.close();
+    }
+}

--- a/libs/libvtrutil/src/vtr_log.h
+++ b/libs/libvtrutil/src/vtr_log.h
@@ -1,6 +1,8 @@
 #ifndef VTR_LOG_H
 #define VTR_LOG_H
 #include <tuple>
+#include <unordered_set>
+#include <string>
 
 /*
  * This header defines useful logging macros for VTR projects.
@@ -71,20 +73,29 @@
 #define VTR_LOGF_ERROR(file, line, ...) VTR_LOGVF_ERROR(true, file, line, __VA_ARGS__)
 #define VTR_LOGF_NOP(file, line, ...) VTR_LOGVF_NOP(true, file, line, __VA_ARGS__)
 
+//Custom file-line-func location logging macros
+#define VTR_LOGFF_WARN(file, line, func, ...) VTR_LOGVFF_WARN(true, file, line, func, __VA_ARGS__)
+
 //Conditional logging and custom file-line location macros
 #define VTR_LOGVF(expr, file, line, ...)    \
     do {                                    \
         if (expr) vtr::printf(__VA_ARGS__); \
     } while (false)
 
-#define VTR_LOGVF_WARN(expr, file, line, ...)                   \
-    do {                                                        \
-        if (expr) vtr::printf_warning(file, line, __VA_ARGS__); \
+#define VTR_LOGVF_WARN(expr, file, line, ...)                          \
+    do {                                                               \
+        if (expr) suppress_warning(file, line, __func__, __VA_ARGS__); \
     } while (false)
 
 #define VTR_LOGVF_ERROR(expr, file, line, ...)                \
     do {                                                      \
         if (expr) vtr::printf_error(file, line, __VA_ARGS__); \
+    } while (false)
+
+// Conditional logging and custom file-line-func location macros
+#define VTR_LOGVFF_WARN(expr, file, line, func, ...)               \
+    do {                                                           \
+        if (expr) suppress_warning(file, line, func, __VA_ARGS__); \
     } while (false)
 
 //No-op version of logging macro which avoids unused parameter warnings.
@@ -128,5 +139,15 @@ extern PrintHandlerDirect printf_direct;
 void set_log_file(const char* filename);
 
 } // namespace vtr
+
+// The following data structure and functions allow to suppress noisy warnings
+// and direct them into an external file.
+static std::unordered_set<std::string> warnings_to_suppress;
+static std::string noisy_warn_log_file;
+
+void add_warnings_to_suppress(std::string function_name);
+void set_noisy_warn_log_file(const char* log_file_name);
+
+void suppress_warning(const char* pszFileName, unsigned int lineNum, const char* pszFuncName, const char* pszMessage, ...);
 
 #endif

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -347,8 +347,8 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
     RouterOpts->max_convergence_count = Options.router_max_convergence_count;
     RouterOpts->reconvergence_cpd_threshold = Options.router_reconvergence_cpd_threshold;
     RouterOpts->first_iteration_timing_report_file = Options.router_first_iteration_timing_report_file;
-
     RouterOpts->strict_checks = Options.strict_checks;
+    RouterOpts->disable_check_route = Options.disable_check_route;
 }
 
 static void SetupAnnealSched(const t_options& Options,

--- a/vpr/src/base/echo_files.cpp
+++ b/vpr/src/base/echo_files.cpp
@@ -112,6 +112,8 @@ void alloc_and_load_echo_file_info() {
     setEchoFileName(E_ECHO_CHAN_DETAILS, "chan_details.txt");
     setEchoFileName(E_ECHO_SBLOCK_PATTERN, "sblock_pattern.txt");
     setEchoFileName(E_ECHO_ENDPOINT_TIMING, "endpoint_timing.echo.json");
+
+    setEchoFileName(E_ECHO_LOOKAHEAD_MAP, "lookahead_map.echo");
 }
 
 void free_echo_file_info() {

--- a/vpr/src/base/echo_files.h
+++ b/vpr/src/base/echo_files.h
@@ -43,6 +43,7 @@ enum e_echo_files {
     E_ECHO_CHAN_DETAILS,
     E_ECHO_SBLOCK_PATTERN,
     E_ECHO_ENDPOINT_TIMING,
+    E_ECHO_LOOKAHEAD_MAP,
 
     //Timing Graphs
     E_ECHO_PRE_PACKING_TIMING_GRAPH,

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -931,6 +931,22 @@ static argparse::ArgumentParser create_arg_parser(std::string prog_name, t_optio
         .default_value("on")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    gen_grp.add_argument<std::string>(args.disable_errors, "--disable_errors")
+        .help(
+            "Parses a list of functions for which the errors are going to be treated as warnings.\n"
+            "Each function in the list is delimited by `:`\n"
+            "This option should be only used for development purposes.")
+        .default_value("");
+
+    gen_grp.add_argument<std::string>(args.suppress_warnings, "--suppress_warnings")
+        .help(
+            "Parses a list of functions for which the warnings will be suppressed on stdout.\n"
+            "The first element of the list is the name of the output log file with the suppressed warnings.\n"
+            "The file name and the list of functions is separated by `,`\n"
+            "Each function in the list is delimited by `:`\n"
+            "This option should be only used for development purposes.")
+        .default_value("");
+
     auto& file_grp = parser.add_argument_group("file options");
 
     file_grp.add_argument(args.BlifFile, "--circuit_file")

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1533,6 +1533,11 @@ static argparse::ArgumentParser create_arg_parser(std::string prog_name, t_optio
         .default_value("")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    route_timing_grp.add_argument<bool, ParseOnOff>(args.disable_check_route, "--disable_check_route")
+        .help("Disables check_route once routing step has finished or when routing file is loaded")
+        .default_value("off")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     route_timing_grp.add_argument(args.router_debug_net, "--router_debug_net")
         .help(
             "Controls when router debugging is enabled.\n"

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -931,6 +931,16 @@ static argparse::ArgumentParser create_arg_parser(std::string prog_name, t_optio
         .default_value("on")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    gen_grp.add_argument<bool, ParseOnOff>(args.allow_dangling_combinational_nodes, "--allow_dangling_combinational_nodes")
+        .help(
+            "Option to allow dangling combinational nodes in the timing graph.\n"
+            "This option should normally be off, as dangling combinational nodes are unusual\n"
+            "in the timing graph and may indicate a problem in the circuit or architecture.\n"
+            "Unless you understand why your architecture/circuit can have valid dangling combinational nodes, this option should be off.\n"
+            "In general this is a dev-only option and should not be turned on by the end-user.")
+        .default_value("off")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     auto& file_grp = parser.add_argument_group("file options");
 
     file_grp.add_argument(args.BlifFile, "--circuit_file")

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -648,6 +648,8 @@ struct ParseRouterLookahead {
             conv_value.set_value(e_router_lookahead::CLASSIC);
         else if (str == "map")
             conv_value.set_value(e_router_lookahead::MAP);
+        else if (str == "connection_box_map")
+            conv_value.set_value(e_router_lookahead::CONNECTION_BOX_MAP);
         else {
             std::stringstream msg;
             msg << "Invalid conversion from '"
@@ -661,17 +663,22 @@ struct ParseRouterLookahead {
 
     ConvertedValue<std::string> to_str(e_router_lookahead val) {
         ConvertedValue<std::string> conv_value;
-        if (val == e_router_lookahead::CLASSIC)
+        if (val == e_router_lookahead::CLASSIC) {
             conv_value.set_value("classic");
-        else {
-            VTR_ASSERT(val == e_router_lookahead::MAP);
+        } else if (val == e_router_lookahead::MAP) {
             conv_value.set_value("map");
+        } else if (val == e_router_lookahead::CONNECTION_BOX_MAP) {
+            conv_value.set_value("connection_box_map");
+        } else {
+            std::stringstream msg;
+            msg << "Unrecognized e_router_lookahead";
+            conv_value.set_error(msg.str());
         }
         return conv_value;
     }
 
     std::vector<std::string> default_choices() {
-        return {"classic", "map"};
+        return {"classic", "map", "connection_box_map"};
     }
 };
 

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -50,6 +50,8 @@ struct t_options {
     argparse::ArgValue<e_clock_modeling> clock_modeling;
     argparse::ArgValue<bool> exit_before_pack;
     argparse::ArgValue<bool> strict_checks;
+    argparse::ArgValue<std::string> disable_errors;
+    argparse::ArgValue<std::string> suppress_warnings;
 
     /* Atom netlist options */
     argparse::ArgValue<bool> absorb_buffer_luts;

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -50,6 +50,7 @@ struct t_options {
     argparse::ArgValue<e_clock_modeling> clock_modeling;
     argparse::ArgValue<bool> exit_before_pack;
     argparse::ArgValue<bool> strict_checks;
+    argparse::ArgValue<bool> allow_dangling_combinational_nodes;
 
     /* Atom netlist options */
     argparse::ArgValue<bool> absorb_buffer_luts;

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -118,6 +118,7 @@ struct t_options {
     argparse::ArgValue<bool> verify_binary_search;
     argparse::ArgValue<e_router_algorithm> RouterAlgorithm;
     argparse::ArgValue<int> min_incremental_reroute_fanout;
+    argparse::ArgValue<bool> disable_check_route;
 
     /* Timing-driven router options only */
     argparse::ArgValue<float> astar_fac;

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -275,7 +275,7 @@ void vpr_init(const int argc, const char** argv, t_options* options, t_vpr_setup
         auto& timing_ctx = g_vpr_ctx.mutable_timing();
         {
             vtr::ScopedStartFinishTimer t("Build Timing Graph");
-            timing_ctx.graph = TimingGraphBuilder(atom_ctx.nlist, atom_ctx.lookup).timing_graph();
+            timing_ctx.graph = TimingGraphBuilder(atom_ctx.nlist, atom_ctx.lookup).timing_graph(options->allow_dangling_combinational_nodes);
             VTR_LOG("  Timing Graph Nodes: %zu\n", timing_ctx.graph->nodes().size());
             VTR_LOG("  Timing Graph Edges: %zu\n", timing_ctx.graph->edges().size());
             VTR_LOG("  Timing Graph Levels: %zu\n", timing_ctx.graph->levels().size());

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -214,6 +214,29 @@ void vpr_init(const int argc, const char** argv, t_options* options, t_vpr_setup
     /* Determine whether echo is on or off */
     setEchoEnabled(options->CreateEchoFile);
 
+    /*
+     * Initialize the functions names for which VPR_THROWs
+     * are demoted to VTR_LOG_WARNs
+     */
+    for (std::string func_name : vtr::split(options->disable_errors, std::string(":"))) {
+        map_error_activation_status(func_name);
+    }
+
+    /*
+     * Initialize the functions names for which
+     * warnings are being suppressed
+     */
+    std::vector<std::string> split_warning_option = vtr::split(options->suppress_warnings, std::string(","));
+
+    // If the file or the list of functions is not provided
+    // no warning is suppressed
+    if (split_warning_option.size() == 2) {
+        set_noisy_warn_log_file(split_warning_option[0].data());
+        for (std::string func_name : vtr::split(split_warning_option[1], std::string(":"))) {
+            add_warnings_to_suppress(func_name);
+        }
+    }
+
     /* Read in arch and circuit */
     SetupVPR(options,
              vpr_setup->TimingEnabled,

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -637,7 +637,9 @@ RouteStatus vpr_route_flow(t_vpr_setup& vpr_setup, const t_arch& arch) {
         std::string graphics_msg;
         if (route_status.success()) {
             //Sanity check the routing
-            check_route(router_opts.route_type);
+            if (!router_opts.disable_check_route) {
+                check_route(router_opts.route_type);
+            }
             get_serial_num();
 
             //Update status

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -20,6 +20,7 @@
 #include "clock_connection_builders.h"
 #include "route_traceback.h"
 #include "place_macro.h"
+#include "connection_box.h"
 
 //A Context is collection of state relating to a particular part of VPR
 //
@@ -194,6 +195,8 @@ struct DeviceContext : public Context {
      * Clock Network
      ********************************************************************/
     t_clock_arch* clock_arch;
+
+    ConnectionBoxes connection_boxes;
 };
 
 //State relating to power analysis

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -103,7 +103,10 @@ constexpr const char* EMPTY_BLOCK_NAME = "EMPTY";
 enum class e_router_lookahead {
     CLASSIC, //VPR's classic lookahead (assumes uniform wire types)
     MAP,     //Lookahead considering different wire types (see Oleg Petelin's MASc Thesis)
-    NO_OP    //A no-operation lookahead which always returns zero
+    NO_OP,   //A no-operation lookahead which always returns zero
+    CONNECTION_BOX_MAP,
+    // Lookahead considering different wire types and IPIN
+    // connection box.
 };
 
 enum class e_route_bb_update {

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -947,6 +947,7 @@ struct t_router_opts {
     float reconvergence_cpd_threshold;
     std::string first_iteration_timing_report_file;
     bool strict_checks;
+    bool disable_check_route;
 };
 
 struct t_analysis_opts {

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -963,11 +963,7 @@ static void recompute_costs_from_scratch(const t_placer_opts& placer_opts, const
     if (fabs(new_bb_cost - costs->bb_cost) > costs->bb_cost * ERROR_TOL) {
         std::string msg = vtr::string_fmt("in recompute_costs_from_scratch: new_bb_cost = %g, old bb_cost = %g\n",
                                           new_bb_cost, costs->bb_cost);
-        if (placer_opts.strict_checks) {
-            vpr_throw(VPR_ERROR_PLACE, __FILE__, __LINE__, msg.c_str());
-        } else {
-            VTR_LOG_WARN(msg.c_str());
-        }
+        VPR_THROW(VPR_ERROR_PLACE, msg.c_str());
     }
     costs->bb_cost = new_bb_cost;
 
@@ -977,11 +973,7 @@ static void recompute_costs_from_scratch(const t_placer_opts& placer_opts, const
         if (fabs(new_timing_cost - costs->timing_cost) > costs->timing_cost * ERROR_TOL) {
             std::string msg = vtr::string_fmt("in recompute_costs_from_scratch: new_timing_cost = %g, old timing_cost = %g, ERROR_TOL = %g\n",
                                               new_timing_cost, costs->timing_cost, ERROR_TOL);
-            if (placer_opts.strict_checks) {
-                vpr_throw(VPR_ERROR_PLACE, __FILE__, __LINE__, msg.c_str());
-            } else {
-                VTR_LOG_WARN(msg.c_str());
-            }
+            VPR_THROW(VPR_ERROR_PLACE, msg.c_str());
         }
         costs->timing_cost = new_timing_cost;
     } else {

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -264,9 +264,14 @@ static float route_connection_delay(int source_x, int source_y, int sink_x, int 
 
             VTR_ASSERT(sink_rr_node != OPEN);
 
-            successfully_routed = calculate_delay(source_rr_node, sink_rr_node,
-                                                  router_opts,
-                                                  &net_delay_value);
+            {
+                vtr::ScopedStartFinishTimer timer(vtr::string_fmt(
+                    "Routing Src: %d Sink: %d", source_rr_node,
+                    sink_rr_node));
+                successfully_routed = calculate_delay(source_rr_node, sink_rr_node,
+                                                      router_opts,
+                                                      &net_delay_value);
+            }
 
             if (successfully_routed) break;
         }

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -118,7 +118,7 @@ void check_route(enum e_route_type route_type) {
             } else { //Continuing along existing branch
                 connects = check_adjacent(prev_node, inode);
                 if (!connects) {
-                    vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+                    VPR_THROW(VPR_ERROR_ROUTE,
                               "in check_route: found non-adjacent segments in traceback while checking net %d:\n"
                               "  %s\n"
                               "  %s\n",

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -502,7 +502,7 @@ static void check_unbuffered_edges(int from_node) {
         }
 
         if (trans_matched == false) {
-            vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+            VPR_THROW(VPR_ERROR_ROUTE,
                       "in check_unbuffered_edges:\n"
                       "connection from node %d to node %d uses an unbuffered switch (switch type %d '%s')\n"
                       "but there is no corresponding unbuffered switch edge in the other direction.\n",

--- a/vpr/src/route/connection_box.cpp
+++ b/vpr/src/route/connection_box.cpp
@@ -1,0 +1,127 @@
+#include "connection_box.h"
+#include "vtr_assert.h"
+#include "globals.h"
+
+ConnectionBoxes::ConnectionBoxes()
+    : size_(std::make_pair(0, 0)) {
+}
+
+size_t ConnectionBoxes::num_connection_box_types() const {
+    return boxes_.size();
+}
+
+std::pair<size_t, size_t> ConnectionBoxes::connection_box_grid_size() const {
+    return size_;
+}
+
+const ConnectionBox* ConnectionBoxes::get_connection_box(ConnectionBoxId box) const {
+    if (bool(box)) {
+        return nullptr;
+    }
+
+    size_t index = size_t(box);
+    if (index >= boxes_.size()) {
+        return nullptr;
+    }
+
+    return &boxes_.at(index);
+}
+
+bool ConnectionBoxes::find_connection_box(int inode,
+                                          ConnectionBoxId* box_id,
+                                          std::pair<size_t, size_t>* box_location) const {
+    VTR_ASSERT(box_id != nullptr);
+    VTR_ASSERT(box_location != nullptr);
+
+    const auto& conn_box_loc = ipin_map_[inode];
+    if (conn_box_loc.box_id == ConnectionBoxId::INVALID()) {
+        return false;
+    }
+
+    *box_id = conn_box_loc.box_id;
+    *box_location = conn_box_loc.box_location;
+    return true;
+}
+
+// Clear IPIN map and set connection box grid size and box ids.
+void ConnectionBoxes::reset_boxes(std::pair<size_t, size_t> size,
+                                  const std::vector<ConnectionBox> boxes) {
+    clear();
+
+    size_ = size;
+    boxes_ = boxes;
+}
+
+void ConnectionBoxes::resize_nodes(size_t rr_node_size) {
+    ipin_map_.resize(rr_node_size);
+    canonical_loc_map_.resize(rr_node_size,
+                              std::make_pair(-1, -1));
+}
+
+void ConnectionBoxes::clear() {
+    ipin_map_.clear();
+    size_ = std::make_pair(0, 0);
+    boxes_.clear();
+    canonical_loc_map_.clear();
+    sink_to_ipin_.clear();
+}
+
+void ConnectionBoxes::add_connection_box(int inode, ConnectionBoxId box_id, std::pair<size_t, size_t> box_location) {
+    // Ensure that box location is in bounds
+    VTR_ASSERT(box_location.first < size_.first);
+    VTR_ASSERT(box_location.second < size_.second);
+
+    // Bounds check box_id
+    VTR_ASSERT(bool(box_id));
+    VTR_ASSERT(size_t(box_id) < boxes_.size());
+
+    // Make sure sink map will not be invalidated upon insertion.
+    VTR_ASSERT(sink_to_ipin_.size() == 0);
+
+    ipin_map_[inode] = ConnBoxLoc(box_location, box_id);
+}
+
+void ConnectionBoxes::add_canonical_loc(int inode, std::pair<size_t, size_t> loc) {
+    VTR_ASSERT(loc.first < size_.first);
+    VTR_ASSERT(loc.second < size_.second);
+    canonical_loc_map_[inode] = loc;
+}
+
+const std::pair<size_t, size_t>* ConnectionBoxes::find_canonical_loc(int inode) const {
+    const auto& canon_loc = canonical_loc_map_[inode];
+    if (canon_loc.first == size_t(-1)) {
+        return nullptr;
+    }
+
+    return &canon_loc;
+}
+
+void ConnectionBoxes::create_sink_back_ref() {
+    const auto& device_ctx = g_vpr_ctx.device();
+
+    sink_to_ipin_.resize(device_ctx.rr_nodes.size(), {{0, 0, 0, 0}, 0});
+
+    for (size_t i = 0; i < device_ctx.rr_nodes.size(); ++i) {
+        const auto& ipin_node = device_ctx.rr_nodes[i];
+        if (ipin_node.type() != IPIN) {
+            continue;
+        }
+
+        if (ipin_map_[i].box_id == ConnectionBoxId::INVALID()) {
+            continue;
+        }
+
+        for (auto edge : ipin_node.edges()) {
+            int sink_inode = ipin_node.edge_sink_node(edge);
+            VTR_ASSERT(device_ctx.rr_nodes[sink_inode].type() == SINK);
+            VTR_ASSERT(sink_to_ipin_[sink_inode].ipin_count < 4);
+            auto& sink_to_ipin = sink_to_ipin_[sink_inode];
+            sink_to_ipin.ipin_nodes[sink_to_ipin.ipin_count++] = i;
+        }
+    }
+}
+
+const SinkToIpin& ConnectionBoxes::find_sink_connection_boxes(
+    int inode) const {
+    return sink_to_ipin_[inode];
+}

--- a/vpr/src/route/connection_box.h
+++ b/vpr/src/route/connection_box.h
@@ -1,0 +1,76 @@
+#ifndef CONNECTION_BOX_H
+#define CONNECTION_BOX_H
+// Some routing graphs have connectivity driven by types of connection boxes.
+// This class relates IPIN rr nodes with connection box type and locations, used
+// for connection box driven map lookahead.
+
+#include <tuple>
+#include "vtr_strong_id.h"
+#include "vtr_flat_map.h"
+#include "vtr_range.h"
+#include <map>
+
+struct connection_box_tag {};
+typedef vtr::StrongId<connection_box_tag> ConnectionBoxId;
+
+struct ConnectionBox {
+    std::string name;
+};
+
+struct ConnBoxLoc {
+    ConnBoxLoc()
+        : box_location(std::make_pair(-1, -1)) {}
+    ConnBoxLoc(
+        const std::pair<size_t, size_t>& a_box_location,
+        ConnectionBoxId a_box_id)
+        : box_location(a_box_location)
+        , box_id(a_box_id) {}
+
+    std::pair<size_t, size_t> box_location;
+    ConnectionBoxId box_id;
+};
+
+struct SinkToIpin {
+    int ipin_nodes[4];
+    int ipin_count;
+};
+
+class ConnectionBoxes {
+  public:
+    ConnectionBoxes();
+
+    size_t num_connection_box_types() const;
+    std::pair<size_t, size_t> connection_box_grid_size() const;
+    const ConnectionBox* get_connection_box(ConnectionBoxId box) const;
+
+    bool find_connection_box(int inode,
+                             ConnectionBoxId* box_id,
+                             std::pair<size_t, size_t>* box_location) const;
+    const std::pair<size_t, size_t>* find_canonical_loc(int inode) const;
+
+    // Clear IPIN map and set connection box grid size and box ids.
+    void clear();
+    void reset_boxes(std::pair<size_t, size_t> size,
+                     const std::vector<ConnectionBox> boxes);
+    void resize_nodes(size_t rr_node_size);
+
+    void add_connection_box(int inode, ConnectionBoxId box_id, std::pair<size_t, size_t> box_location);
+    void add_canonical_loc(int inode, std::pair<size_t, size_t> loc);
+
+    // Create map from SINK's back to IPIN's
+    //
+    // This must be called after all connection boxes have been added.
+    void create_sink_back_ref();
+    const SinkToIpin& find_sink_connection_boxes(
+        int inode) const;
+
+  private:
+    std::pair<size_t, size_t> size_;
+    std::vector<ConnectionBox> boxes_;
+    std::vector<ConnBoxLoc> ipin_map_;
+    std::vector<SinkToIpin> sink_to_ipin_;
+    std::vector<std::pair<size_t, size_t>>
+        canonical_loc_map_;
+};
+
+#endif

--- a/vpr/src/route/connection_box_lookahead_map.cpp
+++ b/vpr/src/route/connection_box_lookahead_map.cpp
@@ -1,0 +1,460 @@
+#include "connection_box_lookahead_map.h"
+
+#include <vector>
+#include <queue>
+
+#include "connection_box.h"
+#include "rr_node.h"
+#include "router_lookahead_map_utils.h"
+#include "globals.h"
+#include "vtr_math.h"
+#include "vtr_time.h"
+#include "echo_files.h"
+
+/* we're profiling routing cost over many tracks for each wire type, so we'll
+ * have many cost entries at each |dx|,|dy| offset. There are many ways to
+ * "boil down" the many costs at each offset to a single entry for a given
+ * (wire type, chan_type) combination we can take the smallest cost, the
+ * average, median, etc. This define selects the method we use.
+ *
+ * See e_representative_entry_method */
+#define REPRESENTATIVE_ENTRY_METHOD SMALLEST
+
+#define REF_X 25
+#define REF_Y 23
+
+static int signum(int x) {
+    if (x > 0) return 1;
+    if (x < 0)
+        return -1;
+    else
+        return 0;
+}
+
+typedef std::vector<std::pair<std::pair<int, int>, Cost_Entry>> t_routing_cost_map;
+static void run_dijkstra(int start_node_ind,
+                         t_routing_cost_map* cost_map);
+
+class CostMap {
+  public:
+    void set_segment_count(size_t seg_count) {
+        cost_map_.clear();
+        offset_.clear();
+        cost_map_.resize(seg_count);
+        offset_.resize(seg_count);
+
+        const auto& device_ctx = g_vpr_ctx.device();
+        segment_map_.resize(device_ctx.rr_nodes.size());
+        for (size_t i = 0; i < segment_map_.size(); ++i) {
+            auto& from_node = device_ctx.rr_nodes[i];
+
+            int from_cost_index = from_node.cost_index();
+            int from_seg_index = device_ctx.rr_indexed_data[from_cost_index].seg_index;
+
+            segment_map_[i] = from_seg_index;
+        }
+    }
+
+    int node_to_segment(int from_node_ind) {
+        return segment_map_[from_node_ind];
+    }
+
+    Cost_Entry find_cost(int from_seg_index, int delta_x, int delta_y) const {
+        VTR_ASSERT(from_seg_index >= 0 && from_seg_index < (ssize_t)offset_.size());
+        int dx = delta_x - offset_[from_seg_index].first;
+        int dy = delta_y - offset_[from_seg_index].second;
+        const auto& cost_map = cost_map_[from_seg_index];
+
+        if (dx < 0) {
+            dx = 0;
+        }
+        if (dy < 0) {
+            dy = 0;
+        }
+
+        if (dx >= (ssize_t)cost_map.dim_size(0)) {
+            dx = cost_map.dim_size(0) - 1;
+        }
+        if (dy >= (ssize_t)cost_map.dim_size(1)) {
+            dy = cost_map.dim_size(1) - 1;
+        }
+
+        return cost_map_[from_seg_index][dx][dy];
+    }
+
+    void set_cost_map(int from_seg_index,
+                      const t_routing_cost_map& cost_map,
+                      e_representative_entry_method method) {
+        VTR_ASSERT(from_seg_index >= 0 && from_seg_index < (ssize_t)offset_.size());
+
+        // Find coordinate offset for this segment.
+        int min_dx = 0;
+        int min_dy = 0;
+        int max_dx = 0;
+        int max_dy = 0;
+        for (const auto& entry : cost_map) {
+            min_dx = std::min(entry.first.first, min_dx);
+            min_dy = std::min(entry.first.second, min_dy);
+
+            max_dx = std::max(entry.first.first, max_dx);
+            max_dy = std::max(entry.first.second, max_dy);
+        }
+
+        offset_[from_seg_index].first = min_dx;
+        offset_[from_seg_index].second = min_dy;
+        size_t dim_x = max_dx - min_dx + 1;
+        size_t dim_y = max_dy - min_dy + 1;
+
+        vtr::NdMatrix<Expansion_Cost_Entry, 2> expansion_cost_map(
+            {dim_x, dim_y});
+
+        for (const auto& entry : cost_map) {
+            int x = entry.first.first - min_dx;
+            int y = entry.first.second - min_dy;
+            expansion_cost_map[x][y].add_cost_entry(
+                method, entry.second.delay,
+                entry.second.congestion);
+        }
+
+        cost_map_[from_seg_index] = vtr::NdMatrix<Cost_Entry, 2>(
+            {dim_x, dim_y});
+
+        /* set the lookahead cost map entries with a representative cost
+         * entry from routing_cost_map */
+        for (unsigned ix = 0; ix < expansion_cost_map.dim_size(0); ix++) {
+            for (unsigned iy = 0; iy < expansion_cost_map.dim_size(1); iy++) {
+                cost_map_[from_seg_index][ix][iy] = expansion_cost_map[ix][iy].get_representative_cost_entry(method);
+            }
+        }
+
+        /* find missing cost entries and fill them in by copying a nearby cost entry */
+        for (unsigned ix = 0; ix < expansion_cost_map.dim_size(0); ix++) {
+            for (unsigned iy = 0; iy < expansion_cost_map.dim_size(1); iy++) {
+                Cost_Entry cost_entry = cost_map_[from_seg_index][ix][iy];
+
+                if (!cost_entry.valid()) {
+                    Cost_Entry copied_entry = get_nearby_cost_entry(
+                        from_seg_index,
+                        offset_[from_seg_index].first + ix,
+                        offset_[from_seg_index].second + iy);
+                    cost_map_[from_seg_index][ix][iy] = copied_entry;
+                }
+            }
+        }
+    }
+
+    Cost_Entry get_nearby_cost_entry(int segment_index, int x, int y) {
+        /* compute the slope from x,y to 0,0 and then move towards 0,0 by one
+         * unit to get the coordinates of the cost entry to be copied */
+
+        float slope;
+        int copy_x, copy_y;
+        if (x == 0 || y == 0) {
+            slope = std::numeric_limits<float>::infinity();
+            copy_x = x - signum(x);
+            copy_y = y - signum(y);
+        } else {
+            slope = (float)y / (float)x;
+            if (slope >= 1.0) {
+                copy_y = y - signum(y);
+                copy_x = vtr::nint((float)y / slope);
+            } else {
+                copy_x = x - signum(x);
+                copy_y = vtr::nint((float)x * slope);
+            }
+        }
+
+        Cost_Entry copy_entry = find_cost(segment_index, copy_x, copy_y);
+
+        /* if the entry to be copied is also empty, recurse */
+        if (copy_entry.valid()) {
+            return copy_entry;
+        } else if (copy_x == 0 && copy_y == 0) {
+            return Cost_Entry();
+        }
+
+        return get_nearby_cost_entry(segment_index, copy_x, copy_y);
+    }
+
+    void print_cost_map(const std::vector<t_segment_inf>& segment_inf,
+                        const char* fname) {
+        FILE* fp = vtr::fopen(fname, "w");
+        for (size_t iseg = 0; iseg < cost_map_.size(); iseg++) {
+            fprintf(fp, "Seg %s(%zu) (%d, %d)\n", segment_inf.at(iseg).name.c_str(),
+                    iseg,
+                    offset_[iseg].first,
+                    offset_[iseg].second);
+            for (size_t iy = 0; iy < cost_map_[iseg].dim_size(1); iy++) {
+                for (size_t ix = 0; ix < cost_map_[iseg].dim_size(0); ix++) {
+                    fprintf(fp, "%.4g,\t",
+                            cost_map_[iseg][ix][iy].delay);
+                }
+                fprintf(fp, "\n");
+            }
+            fprintf(fp, "\n\n");
+        }
+
+        fclose(fp);
+    }
+
+  private:
+    std::vector<vtr::NdMatrix<Cost_Entry, 2>> cost_map_;
+    std::vector<std::pair<int, int>> offset_;
+    std::vector<int> segment_map_;
+};
+
+static CostMap g_cost_map;
+
+class StartNode {
+  public:
+    StartNode(int start_x, int start_y, t_rr_type rr_type, int seg_index)
+        : start_x_(start_x)
+        , start_y_(start_y)
+        , rr_type_(rr_type)
+        , seg_index_(seg_index)
+        , index_(0) {}
+    int get_next_node() {
+        const auto& device_ctx = g_vpr_ctx.device();
+        const std::vector<int>& channel_node_list = device_ctx.rr_node_indices[rr_type_][start_x_][start_y_][0];
+
+        for (; index_ < channel_node_list.size(); index_++) {
+            int node_ind = channel_node_list[index_];
+
+            if (node_ind == OPEN || device_ctx.rr_nodes[node_ind].capacity() == 0) {
+                continue;
+            }
+
+            const std::pair<size_t, size_t>* loc = device_ctx.connection_boxes.find_canonical_loc(node_ind);
+            if (loc == nullptr) {
+                continue;
+            }
+
+            int node_cost_ind = device_ctx.rr_nodes[node_ind].cost_index();
+            int node_seg_ind = device_ctx.rr_indexed_data[node_cost_ind].seg_index;
+            if (node_seg_ind == seg_index_) {
+                index_ += 1;
+                return node_ind;
+            }
+        }
+
+        return UNDEFINED;
+    }
+
+  private:
+    int start_x_;
+    int start_y_;
+    t_rr_type rr_type_;
+    int seg_index_;
+    size_t index_;
+};
+
+// Minimum size of search for channels to profile.  kMinProfile results
+// in searching x = [0, kMinProfile], and y = [0, kMinProfile[.
+//
+// Making this value larger will increase the sample size, but also the runtime
+// to produce the lookahead.
+static constexpr int kMinProfile = 1;
+
+// Maximum size of search for channels to profile.  Once search is outside of
+// kMinProfile distance, lookahead will stop searching once:
+//  - At least one channel has been profiled
+//  - kMaxProfile is exceeded.
+static constexpr int kMaxProfile = 7;
+
+void compute_connection_box_lookahead(
+    const std::vector<t_segment_inf>& segment_inf) {
+    size_t num_segments = segment_inf.size();
+    vtr::ScopedStartFinishTimer timer("Computing connection box lookahead map");
+
+    /* free previous delay map and allocate new one */
+    g_cost_map.set_segment_count(segment_inf.size());
+
+    /* run Dijkstra's algorithm for each segment type & channel type combination */
+    for (int iseg = 0; iseg < (ssize_t)num_segments; iseg++) {
+        VTR_LOG("Creating cost map for %s(%d)\n",
+                segment_inf[iseg].name.c_str(), iseg);
+        /* allocate the cost map for this iseg/chan_type */
+        t_routing_cost_map cost_map;
+
+        int count = 0;
+
+        int dx = 0;
+        int dy = 0;
+        //int start_x = vtr::nint(device_ctx.grid.width()/2);
+        //int start_y = vtr::nint(device_ctx.grid.height()/2);
+        int start_x = REF_X;
+        int start_y = REF_Y;
+        while ((count == 0 && dx < kMaxProfile) || dy <= kMinProfile) {
+            for (e_rr_type chan_type : {CHANX, CHANY}) {
+                StartNode start_node(start_x + dx, start_y + dy, chan_type, iseg);
+
+                for (int start_node_ind = start_node.get_next_node();
+                     start_node_ind != UNDEFINED;
+                     start_node_ind = start_node.get_next_node()) {
+                    count += 1;
+
+                    /* run Dijkstra's algorithm */
+                    run_dijkstra(start_node_ind, &cost_map);
+                }
+            }
+
+            if (dy < dx) {
+                dy += 1;
+            } else {
+                dx += 1;
+            }
+        }
+
+        if (count == 0) {
+            VTR_LOG_WARN("Segment %s(%d) found no start_node_ind\n",
+                         segment_inf[iseg].name.c_str(), iseg);
+        }
+
+        /* boil down the cost list in routing_cost_map at each coordinate to a
+         * representative cost entry and store it in the lookahead cost map */
+        g_cost_map.set_cost_map(iseg, cost_map,
+                                REPRESENTATIVE_ENTRY_METHOD);
+    }
+
+    if (getEchoEnabled() && isEchoFileEnabled(E_ECHO_LOOKAHEAD_MAP)) {
+        g_cost_map.print_cost_map(segment_inf, getEchoFileName(E_ECHO_LOOKAHEAD_MAP));
+    }
+}
+
+float get_connection_box_lookahead_map_cost(int from_node_ind,
+                                            int to_node_ind,
+                                            float criticality_fac) {
+    if (from_node_ind == to_node_ind) {
+        return 0.f;
+    }
+
+    auto& device_ctx = g_vpr_ctx.device();
+
+    std::pair<size_t, size_t> from_location;
+    std::pair<size_t, size_t> to_location;
+    auto to_node_type = device_ctx.rr_nodes[to_node_ind].type();
+
+    if (to_node_type == SINK) {
+        const auto& sink_to_ipin = device_ctx.connection_boxes.find_sink_connection_boxes(to_node_ind);
+        if (sink_to_ipin.ipin_count > 1) {
+            float cost = std::numeric_limits<float>::infinity();
+            // Find cheapest cost from from_node_ind to IPINs for this SINK.
+            for (int i = 0; i < sink_to_ipin.ipin_count; ++i) {
+                cost = std::min(cost,
+                                get_connection_box_lookahead_map_cost(
+                                    from_node_ind,
+                                    sink_to_ipin.ipin_nodes[i], criticality_fac));
+            }
+
+            return cost;
+        } else if (sink_to_ipin.ipin_count == 1) {
+            to_node_ind = sink_to_ipin.ipin_nodes[0];
+            if (from_node_ind == to_node_ind) {
+                return 0.f;
+            }
+        } else {
+            return std::numeric_limits<float>::infinity();
+        }
+    }
+
+    if (device_ctx.rr_nodes[to_node_ind].type() == IPIN) {
+        ConnectionBoxId box_id;
+        std::pair<size_t, size_t> box_location;
+        bool found = device_ctx.connection_boxes.find_connection_box(
+            to_node_ind, &box_id, &box_location);
+        if (!found) {
+            VPR_THROW(VPR_ERROR_ROUTE, "No connection box for IPIN %d", to_node_ind);
+        }
+
+        to_location = box_location;
+    } else {
+        const std::pair<size_t, size_t>* to_canonical_loc = device_ctx.connection_boxes.find_canonical_loc(to_node_ind);
+        if (!to_canonical_loc) {
+            VPR_THROW(VPR_ERROR_ROUTE, "No canonical loc for %d", to_node_ind);
+        }
+
+        to_location = *to_canonical_loc;
+    }
+
+    const std::pair<size_t, size_t>* from_canonical_loc = device_ctx.connection_boxes.find_canonical_loc(from_node_ind);
+    if (from_canonical_loc == nullptr) {
+        VPR_THROW(VPR_ERROR_ROUTE, "No canonical loc for %d (to %d)",
+                  from_node_ind, to_node_ind);
+    }
+
+    ssize_t dx = ssize_t(from_canonical_loc->first) - ssize_t(to_location.first);
+    ssize_t dy = ssize_t(from_canonical_loc->second) - ssize_t(to_location.second);
+
+    int from_seg_index = g_cost_map.node_to_segment(from_node_ind);
+    Cost_Entry cost_entry = g_cost_map.find_cost(from_seg_index, dx, dy);
+    float expected_delay = cost_entry.delay;
+    float expected_congestion = cost_entry.congestion;
+
+    float expected_cost = criticality_fac * expected_delay + (1.0 - criticality_fac) * expected_congestion;
+    return expected_cost;
+}
+
+/* runs Dijkstra's algorithm from specified node until all nodes have been
+ * visited. Each time a pin is visited, the delay/congestion information
+ * to that pin is stored to an entry in the routing_cost_map */
+static void run_dijkstra(int start_node_ind,
+                         t_routing_cost_map* routing_cost_map) {
+    auto& device_ctx = g_vpr_ctx.device();
+
+    /* a list of boolean flags (one for each rr node) to figure out if a
+     * certain node has already been expanded */
+    std::vector<bool> node_expanded(device_ctx.rr_nodes.size(), false);
+    /* for each node keep a list of the cost with which that node has been
+     * visited (used to determine whether to push a candidate node onto the
+     * expansion queue */
+    std::vector<float> node_visited_costs(device_ctx.rr_nodes.size(), -1.0);
+    /* a priority queue for expansion */
+    std::priority_queue<PQ_Entry> pq;
+
+    /* first entry has no upstream delay or congestion */
+    PQ_Entry first_entry(start_node_ind, UNDEFINED, 0, 0, 0, true);
+
+    pq.push(first_entry);
+
+    const std::pair<size_t, size_t>* from_canonical_loc = device_ctx.connection_boxes.find_canonical_loc(start_node_ind);
+    if (from_canonical_loc == nullptr) {
+        VPR_THROW(VPR_ERROR_ROUTE, "No canonical location of node %d",
+                  start_node_ind);
+    }
+
+    /* now do routing */
+    while (!pq.empty()) {
+        PQ_Entry current = pq.top();
+        pq.pop();
+
+        int node_ind = current.rr_node_ind;
+
+        /* check that we haven't already expanded from this node */
+        if (node_expanded[node_ind]) {
+            continue;
+        }
+
+        /* if this node is an ipin record its congestion/delay in the routing_cost_map */
+        if (device_ctx.rr_nodes[node_ind].type() == IPIN) {
+            ConnectionBoxId box_id;
+            std::pair<size_t, size_t> box_location;
+            bool found = device_ctx.connection_boxes.find_connection_box(
+                node_ind, &box_id, &box_location);
+            if (!found) {
+                VPR_THROW(VPR_ERROR_ROUTE, "No connection box for IPIN %d", node_ind);
+            }
+
+            int delta_x = ssize_t(from_canonical_loc->first) - ssize_t(box_location.first);
+            int delta_y = ssize_t(from_canonical_loc->second) - ssize_t(box_location.second);
+
+            routing_cost_map->push_back(std::make_pair(
+                std::make_pair(delta_x, delta_y),
+                Cost_Entry(
+                    current.delay,
+                    current.congestion_upstream)));
+        }
+
+        expand_dijkstra_neighbours(current, node_visited_costs, node_expanded, pq);
+        node_expanded[node_ind] = true;
+    }
+}

--- a/vpr/src/route/connection_box_lookahead_map.h
+++ b/vpr/src/route/connection_box_lookahead_map.h
@@ -1,0 +1,14 @@
+#ifndef CONNECTION_BOX_LOOKAHEAD_H_
+#define CONNECTION_BOX_LOOKAHEAD_H_
+
+#include <vector>
+#include "physical_types.h"
+
+void compute_connection_box_lookahead(
+    const std::vector<t_segment_inf>& segment_inf);
+
+float get_connection_box_lookahead_map_cost(int from_node_ind,
+                                            int to_node_ind,
+                                            float criticality_fac);
+
+#endif

--- a/vpr/src/route/router_lookahead.h
+++ b/vpr/src/route/router_lookahead.h
@@ -27,6 +27,11 @@ class MapLookahead : public RouterLookahead {
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
 };
 
+class ConnectionBoxMapLookahead : public RouterLookahead {
+  protected:
+    float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+};
+
 class NoOpLookahead : public RouterLookahead {
   protected:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;

--- a/vpr/src/route/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead_map_utils.cpp
@@ -1,0 +1,192 @@
+#include "router_lookahead_map_utils.h"
+
+#include "globals.h"
+#include "vpr_context.h"
+#include "vtr_math.h"
+
+/* Number of CLBs I think the average conn. goes. */
+static const int CLB_DIST = 3;
+
+PQ_Entry::PQ_Entry(
+    int set_rr_node_ind,
+    int switch_ind,
+    float parent_delay,
+    float parent_R_upstream,
+    float parent_congestion_upstream,
+    bool starting_node) {
+    this->rr_node_ind = set_rr_node_ind;
+
+    auto& device_ctx = g_vpr_ctx.device();
+    this->delay = parent_delay;
+    this->congestion_upstream = parent_congestion_upstream;
+    this->R_upstream = parent_R_upstream;
+    if (!starting_node) {
+        int cost_index = device_ctx.rr_nodes[set_rr_node_ind].cost_index();
+
+        float Tsw = device_ctx.rr_switch_inf[switch_ind].Tdel;
+        float Rsw = device_ctx.rr_switch_inf[switch_ind].R;
+        float Cnode = device_ctx.rr_nodes[set_rr_node_ind].C();
+        float Rnode = device_ctx.rr_nodes[set_rr_node_ind].R();
+
+        float T_linear = 0.f;
+        float T_quadratic = 0.f;
+        if (device_ctx.rr_switch_inf[switch_ind].buffered()) {
+            T_linear = Tsw + Rsw * Cnode + 0.5 * Rnode * Cnode;
+            T_quadratic = 0.;
+        } else { /* Pass transistor */
+            T_linear = Tsw + 0.5 * Rsw * Cnode;
+            T_quadratic = (Rsw + Rnode) * 0.5 * Cnode;
+        }
+
+        float base_cost;
+        if (device_ctx.rr_indexed_data[cost_index].inv_length < 0) {
+            base_cost = device_ctx.rr_indexed_data[cost_index].base_cost;
+        } else {
+            float frac_num_seg = CLB_DIST * device_ctx.rr_indexed_data[cost_index].inv_length;
+
+            base_cost = frac_num_seg * T_linear
+                        + frac_num_seg * frac_num_seg * T_quadratic;
+        }
+
+        VTR_ASSERT(T_linear >= 0.);
+        VTR_ASSERT(base_cost >= 0.);
+        this->delay += T_linear;
+
+        this->congestion_upstream += base_cost;
+    }
+
+    /* set the cost of this node */
+    this->cost = this->delay;
+}
+
+/* returns cost entry with the smallest delay */
+Cost_Entry Expansion_Cost_Entry::get_smallest_entry() const {
+    Cost_Entry smallest_entry;
+
+    for (auto entry : this->cost_vector) {
+        if (!smallest_entry.valid() || entry.delay < smallest_entry.delay) {
+            smallest_entry = entry;
+        }
+    }
+
+    return smallest_entry;
+}
+
+/* returns a cost entry that represents the average of all the recorded entries */
+Cost_Entry Expansion_Cost_Entry::get_average_entry() const {
+    float avg_delay = 0;
+    float avg_congestion = 0;
+
+    for (auto cost_entry : this->cost_vector) {
+        avg_delay += cost_entry.delay;
+        avg_congestion += cost_entry.congestion;
+    }
+
+    avg_delay /= (float)this->cost_vector.size();
+    avg_congestion /= (float)this->cost_vector.size();
+
+    return Cost_Entry(avg_delay, avg_congestion);
+}
+
+/* returns a cost entry that represents the geomean of all the recorded entries */
+Cost_Entry Expansion_Cost_Entry::get_geomean_entry() const {
+    float geomean_delay = 0;
+    float geomean_cong = 0;
+    for (auto cost_entry : this->cost_vector) {
+        geomean_delay += log(cost_entry.delay);
+        geomean_cong += log(cost_entry.congestion);
+    }
+
+    geomean_delay = exp(geomean_delay / (float)this->cost_vector.size());
+    geomean_cong = exp(geomean_cong / (float)this->cost_vector.size());
+
+    return Cost_Entry(geomean_delay, geomean_cong);
+}
+
+/* returns a cost entry that represents the medial of all recorded entries */
+Cost_Entry Expansion_Cost_Entry::get_median_entry() const {
+    /* find median by binning the delays of all entries and then chosing the bin
+     * with the largest number of entries */
+
+    int num_bins = 10;
+
+    /* find entries with smallest and largest delays */
+    Cost_Entry min_del_entry;
+    Cost_Entry max_del_entry;
+    for (auto entry : this->cost_vector) {
+        if (!min_del_entry.valid() || entry.delay < min_del_entry.delay) {
+            min_del_entry = entry;
+        }
+        if (!max_del_entry.valid() || entry.delay > max_del_entry.delay) {
+            max_del_entry = entry;
+        }
+    }
+
+    /* get the bin size */
+    float delay_diff = max_del_entry.delay - min_del_entry.delay;
+    float bin_size = delay_diff / (float)num_bins;
+
+    /* sort the cost entries into bins */
+    std::vector<std::vector<Cost_Entry> > entry_bins(num_bins, std::vector<Cost_Entry>());
+    for (auto entry : this->cost_vector) {
+        float bin_num = floor((entry.delay - min_del_entry.delay) / bin_size);
+
+        VTR_ASSERT(vtr::nint(bin_num) >= 0 && vtr::nint(bin_num) <= num_bins);
+        if (vtr::nint(bin_num) == num_bins) {
+            /* largest entry will otherwise have an out-of-bounds bin number */
+            bin_num -= 1;
+        }
+        entry_bins[vtr::nint(bin_num)].push_back(entry);
+    }
+
+    /* find the bin with the largest number of elements */
+    int largest_bin = 0;
+    int largest_size = 0;
+    for (int ibin = 0; ibin < num_bins; ibin++) {
+        if (entry_bins[ibin].size() > (unsigned)largest_size) {
+            largest_bin = ibin;
+            largest_size = (unsigned)entry_bins[ibin].size();
+        }
+    }
+
+    /* get the representative delay of the largest bin */
+    Cost_Entry representative_entry = entry_bins[largest_bin][0];
+
+    return representative_entry;
+}
+
+/* iterates over the children of the specified node and selectively pushes them onto the priority queue */
+void expand_dijkstra_neighbours(PQ_Entry parent_entry,
+                                std::vector<float>& node_visited_costs,
+                                std::vector<bool>& node_expanded,
+                                std::priority_queue<PQ_Entry>& pq) {
+    auto& device_ctx = g_vpr_ctx.device();
+
+    int parent_ind = parent_entry.rr_node_ind;
+
+    auto& parent_node = device_ctx.rr_nodes[parent_ind];
+
+    for (int iedge = 0; iedge < parent_node.num_edges(); iedge++) {
+        int child_node_ind = parent_node.edge_sink_node(iedge);
+        int switch_ind = parent_node.edge_switch(iedge);
+
+        /* skip this child if it has already been expanded from */
+        if (node_expanded[child_node_ind]) {
+            continue;
+        }
+
+        PQ_Entry child_entry(child_node_ind, switch_ind, parent_entry.delay,
+                             parent_entry.R_upstream, parent_entry.congestion_upstream, false);
+
+        VTR_ASSERT(child_entry.cost >= 0);
+
+        /* skip this child if it has been visited with smaller cost */
+        if (node_visited_costs[child_node_ind] >= 0 && node_visited_costs[child_node_ind] < child_entry.cost) {
+            continue;
+        }
+
+        /* finally, record the cost with which the child was visited and put the child entry on the queue */
+        node_visited_costs[child_node_ind] = child_entry.cost;
+        pq.push(child_entry);
+    }
+}

--- a/vpr/src/route/router_lookahead_map_utils.h
+++ b/vpr/src/route/router_lookahead_map_utils.h
@@ -1,0 +1,142 @@
+#ifndef ROUTER_LOOKAHEAD_MAP_UTILS_H_
+#define ROUTER_LOOKAHEAD_MAP_UTILS_H_
+/*
+ * The router lookahead provides an estimate of the cost from an intermediate node to the target node
+ * during directed (A*-like) routing.
+ *
+ * The VPR 7.0 lookahead (route/route_timing.c ==> get_timing_driven_expected_cost) lower-bounds the remaining delay and
+ * congestion by assuming that a minimum number of wires, of the same type as the current node being expanded, can be used
+ * to complete the route. While this method is efficient, it can run into trouble with architectures that use
+ * multiple interconnected wire types.
+ *
+ * The lookahead in this file pre-computes delay/congestion costs up and to the right of a starting tile. This generates
+ * delay/congestion tables for {CHANX, CHANY} channel types, over all wire types defined in the architecture file.
+ * See Section 3.2.4 in Oleg Petelin's MASc thesis (2016) for more discussion.
+ *
+ */
+
+#include <cmath>
+#include <limits>
+#include <vector>
+#include <queue>
+#include "vpr_types.h"
+
+/* when a list of delay/congestion entries at a coordinate in Cost_Entry is boiled down to a single
+ * representative entry, this enum is passed-in to specify how that representative entry should be
+ * calculated */
+enum e_representative_entry_method {
+    FIRST = 0, //the first cost that was recorded
+    SMALLEST,  //the smallest-delay cost recorded
+    AVERAGE,
+    GEOMEAN,
+    MEDIAN
+};
+
+/* f_cost_map is an array of these cost entries that specifies delay/congestion estimates
+ * to travel relative x/y distances */
+class Cost_Entry {
+  public:
+    float delay;
+    float congestion;
+
+    Cost_Entry() {
+        delay = std::numeric_limits<float>::infinity();
+        congestion = std::numeric_limits<float>::infinity();
+    }
+    Cost_Entry(float set_delay, float set_congestion) {
+        delay = set_delay;
+        congestion = set_congestion;
+    }
+
+    bool valid() const {
+        return std::isfinite(delay) && std::isfinite(congestion);
+    }
+};
+
+/* a class that stores delay/congestion information for a given relative coordinate during the Dijkstra expansion.
+ * since it stores multiple cost entries, it is later boiled down to a single representative cost entry to be stored
+ * in the final lookahead cost map */
+class Expansion_Cost_Entry {
+  private:
+    std::vector<Cost_Entry> cost_vector;
+
+    Cost_Entry get_smallest_entry() const;
+    Cost_Entry get_average_entry() const;
+    Cost_Entry get_geomean_entry() const;
+    Cost_Entry get_median_entry() const;
+
+  public:
+    void add_cost_entry(e_representative_entry_method method,
+                        float add_delay,
+                        float add_congestion) {
+        Cost_Entry cost_entry(add_delay, add_congestion);
+        if (method == SMALLEST) {
+            /* taking the smallest-delay entry anyway, so no need to push back multple entries */
+            if (this->cost_vector.empty()) {
+                this->cost_vector.push_back(cost_entry);
+            } else {
+                if (add_delay < this->cost_vector[0].delay) {
+                    this->cost_vector[0] = cost_entry;
+                }
+            }
+        } else {
+            this->cost_vector.push_back(cost_entry);
+        }
+    }
+    void clear_cost_entries() {
+        this->cost_vector.clear();
+    }
+
+    Cost_Entry get_representative_cost_entry(e_representative_entry_method method) const {
+        Cost_Entry entry;
+
+        if (!cost_vector.empty()) {
+            switch (method) {
+                case FIRST:
+                    entry = cost_vector[0];
+                    break;
+                case SMALLEST:
+                    entry = this->get_smallest_entry();
+                    break;
+                case AVERAGE:
+                    entry = this->get_average_entry();
+                    break;
+                case GEOMEAN:
+                    entry = this->get_geomean_entry();
+                    break;
+                case MEDIAN:
+                    entry = this->get_median_entry();
+                    break;
+                default:
+                    break;
+            }
+        }
+        return entry;
+    }
+};
+
+/* a class that represents an entry in the Dijkstra expansion priority queue */
+class PQ_Entry {
+  public:
+    int rr_node_ind; //index in device_ctx.rr_nodes that this entry represents
+    float cost;      //the cost of the path to get to this node
+
+    /* store backward delay, R and congestion info */
+    float delay;
+    float R_upstream;
+    float congestion_upstream;
+
+    PQ_Entry(int set_rr_node_ind, int /*switch_ind*/, float parent_delay, float parent_R_upstream, float parent_congestion_upstream, bool starting_node);
+
+    bool operator<(const PQ_Entry& obj) const {
+        /* inserted into max priority queue so want queue entries with a lower cost to be greater */
+        return (this->cost > obj.cost);
+    }
+};
+
+void expand_dijkstra_neighbours(PQ_Entry parent_entry,
+                                std::vector<float>& node_visited_costs,
+                                std::vector<bool>& node_expanded,
+                                std::priority_queue<PQ_Entry>& pq);
+
+#endif

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -34,6 +34,7 @@ using namespace std;
 #include "rr_graph_writer.h"
 #include "rr_graph_reader.h"
 #include "router_lookahead_map.h"
+#include "connection_box_lookahead_map.h"
 #include "rr_graph_clock.h"
 
 #include "rr_types.h"
@@ -382,6 +383,10 @@ void create_rr_graph(const t_graph_type graph_type,
 
     if (router_lookahead_type == e_router_lookahead::MAP) {
         compute_router_lookahead(segment_inf.size());
+    }
+
+    if (router_lookahead_type == e_router_lookahead::CONNECTION_BOX_MAP) {
+        compute_connection_box_lookahead(segment_inf);
     }
 
     //Write out rr graph file if needed

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -893,6 +893,7 @@ void load_rr_switch_from_arch_switch(int arch_switch_idx,
     device_ctx.rr_switch_inf[rr_switch_idx].set_type(device_ctx.arch_switch_inf[arch_switch_idx].type());
     device_ctx.rr_switch_inf[rr_switch_idx].R = device_ctx.arch_switch_inf[arch_switch_idx].R;
     device_ctx.rr_switch_inf[rr_switch_idx].Cin = device_ctx.arch_switch_inf[arch_switch_idx].Cin;
+    device_ctx.rr_switch_inf[rr_switch_idx].Cinternal = device_ctx.arch_switch_inf[arch_switch_idx].Cinternal; //now we can retrieve Cinternal from the arch and implement into the rr calculations.
     device_ctx.rr_switch_inf[rr_switch_idx].Cout = device_ctx.arch_switch_inf[arch_switch_idx].Cout;
     device_ctx.rr_switch_inf[rr_switch_idx].Tdel = rr_switch_Tdel;
     device_ctx.rr_switch_inf[rr_switch_idx].mux_trans_size = device_ctx.arch_switch_inf[arch_switch_idx].mux_trans_size;

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -234,11 +234,13 @@ void process_switches(pugi::xml_node parent, const pugiutil::loc_data& loc_data)
             rr_switch.R = get_attribute(SwitchSubnode, "R", loc_data).as_float();
             rr_switch.Cin = get_attribute(SwitchSubnode, "Cin", loc_data).as_float();
             rr_switch.Cout = get_attribute(SwitchSubnode, "Cout", loc_data).as_float();
+            rr_switch.Cinternal = get_attribute(SwitchSubnode, "Cinternal", loc_data).as_float();
             rr_switch.Tdel = get_attribute(SwitchSubnode, "Tdel", loc_data).as_float();
         } else {
             rr_switch.R = 0;
             rr_switch.Cin = 0;
             rr_switch.Cout = 0;
+            rr_switch.Cinternal = 0;
             rr_switch.Tdel = 0;
         }
         SwitchSubnode = get_single_child(Switch, "sizing", loc_data);

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -56,6 +56,7 @@ void verify_blocks(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void process_blocks(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void verify_grid(pugi::xml_node parent, const pugiutil::loc_data& loc_data, const DeviceGrid& grid);
 void process_nodes(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
+void process_connection_boxes(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void process_edges(pugi::xml_node parent, const pugiutil::loc_data& loc_data, int* wire_to_rr_ipin_switch, const int num_rr_switches);
 void process_channels(t_chan_width& chan_width, pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void process_rr_node_indices(const DeviceGrid& grid);
@@ -133,6 +134,13 @@ void load_rr_file(const t_graph_type graph_type,
         next_component = get_first_child(rr_graph, "channels", loc_data);
         process_channels(nodes_per_chan, next_component, loc_data);
 
+        next_component = get_first_child(rr_graph, "connection_boxes", loc_data, OPTIONAL);
+        if (next_component != nullptr) {
+            process_connection_boxes(next_component, loc_data);
+        } else {
+            device_ctx.connection_boxes.clear();
+        }
+
         /* Decode the graph_type */
         bool is_global_graph = (GRAPH_GLOBAL == graph_type ? true : false);
 
@@ -146,6 +154,7 @@ void load_rr_file(const t_graph_type graph_type,
         int num_rr_nodes = count_children(next_component, "node", loc_data);
 
         device_ctx.rr_nodes.resize(num_rr_nodes);
+        device_ctx.connection_boxes.resize_nodes(num_rr_nodes);
         process_nodes(next_component, loc_data);
 
         /* Loads edges, switches, and node look up tables*/
@@ -179,6 +188,7 @@ void load_rr_file(const t_graph_type graph_type,
         device_ctx.chan_width = nodes_per_chan;
 
         check_rr_graph(graph_type, grid, device_ctx.block_types);
+        device_ctx.connection_boxes.create_sink_back_ref();
 
     } catch (XmlError& e) {
         vpr_throw(VPR_ERROR_ROUTE, read_rr_graph_name, e.line(), "%s", e.what());
@@ -304,6 +314,18 @@ void process_nodes(pugi::xml_node parent, const pugiutil::loc_data& loc_data) {
             node.set_type(OPIN);
         } else if (strcmp(node_type, "IPIN") == 0) {
             node.set_type(IPIN);
+
+            pugi::xml_node connection_boxSubnode = get_single_child(rr_node, "connection_box", loc_data, OPTIONAL);
+            if (connection_boxSubnode) {
+                int x = get_attribute(connection_boxSubnode, "x", loc_data).as_int();
+                int y = get_attribute(connection_boxSubnode, "y", loc_data).as_int();
+                int id = get_attribute(connection_boxSubnode, "id", loc_data).as_int();
+
+                device_ctx.connection_boxes.add_connection_box(inode,
+                                                               ConnectionBoxId(id),
+                                                               std::make_pair(x, y));
+            }
+
         } else {
             vpr_throw(VPR_ERROR_OTHER, __FILE__, __LINE__,
                       "Valid inputs for class types are \"CHANX\", \"CHANY\",\"SOURCE\", \"SINK\",\"OPIN\", and \"IPIN\".");
@@ -321,6 +343,15 @@ void process_nodes(pugi::xml_node parent, const pugiutil::loc_data& loc_data) {
                 VTR_ASSERT((strcmp(correct_direction, "NO_DIR") == 0));
                 node.set_direction(NO_DIRECTION);
             }
+        }
+
+        pugi::xml_node connection_boxSubnode = get_single_child(rr_node, "canonical_loc", loc_data, OPTIONAL);
+        if (connection_boxSubnode) {
+            int x = get_attribute(connection_boxSubnode, "x", loc_data).as_int();
+            int y = get_attribute(connection_boxSubnode, "y", loc_data).as_int();
+
+            device_ctx.connection_boxes.add_canonical_loc(inode,
+                                                          std::make_pair(x, y));
         }
 
         node.set_capacity(get_attribute(rr_node, "capacity", loc_data).as_float());
@@ -875,4 +906,27 @@ void set_cost_indices(pugi::xml_node parent, const pugiutil::loc_data& loc_data,
         }
         rr_node = rr_node.next_sibling(rr_node.name());
     }
+}
+
+void process_connection_boxes(pugi::xml_node parent, const pugiutil::loc_data& loc_data) {
+    auto& device_ctx = g_vpr_ctx.mutable_device();
+
+    int x_dim = get_attribute(parent, "x_dim", loc_data).as_int(0);
+    int y_dim = get_attribute(parent, "y_dim", loc_data).as_int(0);
+    int num_boxes = get_attribute(parent, "num_boxes", loc_data).as_int(0);
+    VTR_ASSERT(num_boxes >= 0);
+
+    pugi::xml_node connection_box = get_first_child(parent, "connection_box", loc_data);
+    std::vector<ConnectionBox> boxes(num_boxes);
+    while (connection_box) {
+        int id = get_attribute(connection_box, "id", loc_data).as_int(-1);
+        const char* name = get_attribute(connection_box, "name", loc_data).as_string(nullptr);
+        VTR_ASSERT(id >= 0 && id < num_boxes);
+        VTR_ASSERT(boxes.at(id).name == "");
+        boxes.at(id).name = std::string(name);
+
+        connection_box = connection_box.next_sibling(connection_box.name());
+    }
+
+    device_ctx.connection_boxes.reset_boxes(std::make_pair(x_dim, y_dim), boxes);
 }

--- a/vpr/src/route/rr_graph_writer.cpp
+++ b/vpr/src/route/rr_graph_writer.cpp
@@ -189,7 +189,8 @@ void write_rr_switches(fstream& fp) {
         }
         fp << ">" << endl;
 
-        fp << "\t\t\t<timing R=\"" << setprecision(FLOAT_PRECISION) << rr_switch.R << "\" Cin=\"" << setprecision(FLOAT_PRECISION) << rr_switch.Cin << "\" Cout=\"" << setprecision(FLOAT_PRECISION) << rr_switch.Cout << "\" Tdel=\"" << setprecision(FLOAT_PRECISION) << rr_switch.Tdel << "\"/>" << endl;
+        fp << "\t\t\t<timing R=\"" << setprecision(FLOAT_PRECISION) << rr_switch.R << "\" Cin=\"" << setprecision(FLOAT_PRECISION) << rr_switch.Cin << "\" Cout=\"" << setprecision(FLOAT_PRECISION) << rr_switch.Cout << "\" Cinternal=\"" << setprecision(FLOAT_PRECISION) << rr_switch.Cinternal << //will print display the value of Cinternal
+            "\" Tdel=\"" << setprecision(FLOAT_PRECISION) << rr_switch.Tdel << "\"/>" << endl;
         fp << "\t\t\t<sizing mux_trans_size=\"" << setprecision(FLOAT_PRECISION) << rr_switch.mux_trans_size << "\" buf_size=\"" << setprecision(FLOAT_PRECISION) << rr_switch.buf_size << "\"/>" << endl;
         fp << "\t\t</switch>" << endl;
     }

--- a/vpr/src/route/rr_node.h
+++ b/vpr/src/route/rr_node.h
@@ -173,7 +173,7 @@ class t_rr_node {
     uint16_t edges_capacity_ = 0;
     uint8_t num_non_configurable_edges_ = 0;
 
-    int8_t cost_index_ = -1;
+    uint16_t cost_index_ = -1;
     int16_t rc_index_ = -1;
 
     int16_t xlow_ = -1;

--- a/vpr/src/timing/timing_graph_builder.cpp
+++ b/vpr/src/timing/timing_graph_builder.cpp
@@ -40,8 +40,8 @@ TimingGraphBuilder::TimingGraphBuilder(const AtomNetlist& netlist,
     //pass
 }
 
-std::unique_ptr<TimingGraph> TimingGraphBuilder::timing_graph() {
-    build();
+std::unique_ptr<TimingGraph> TimingGraphBuilder::timing_graph(bool allow_dangling_combinational_nodes) {
+    build(allow_dangling_combinational_nodes);
     opt_memory_layout();
 
     VTR_ASSERT(tg_);
@@ -50,8 +50,12 @@ std::unique_ptr<TimingGraph> TimingGraphBuilder::timing_graph() {
     return std::move(tg_);
 }
 
-void TimingGraphBuilder::build() {
+void TimingGraphBuilder::build(bool allow_dangling_combinational_nodes) {
     tg_ = std::make_unique<tatum::TimingGraph>();
+
+    // Optionally allow dangling combinational nodes.
+    // Set by `--allow_dangling_combinational_nodes on`. Default value is false
+    tg_->set_allow_dangling_combinational_nodes(allow_dangling_combinational_nodes);
 
     for (AtomBlockId blk : netlist_.blocks()) {
         AtomBlockType blk_type = netlist_.block_type(blk);

--- a/vpr/src/timing/timing_graph_builder.h
+++ b/vpr/src/timing/timing_graph_builder.h
@@ -10,10 +10,10 @@ class TimingGraphBuilder {
     TimingGraphBuilder(const AtomNetlist& netlist,
                        AtomLookup& netlist_lookup);
 
-    std::unique_ptr<tatum::TimingGraph> timing_graph();
+    std::unique_ptr<tatum::TimingGraph> timing_graph(bool allow_dangling_combinational_nodes);
 
   private:
-    void build();
+    void build(bool allow_dangling_combinational_nodes);
     void opt_memory_layout();
 
     void add_io_to_timing_graph(const AtomBlockId blk);

--- a/vpr/src/timing/timing_util.cpp
+++ b/vpr/src/timing/timing_util.cpp
@@ -571,6 +571,10 @@ float calc_relaxed_criticality(const std::map<DomainPair, float>& domains_max_re
             max_req += shift;
         }
 
+        if (!std::isfinite(slack)) {
+            continue;
+        }
+
         float crit = std::numeric_limits<float>::quiet_NaN();
         if (max_req > 0.) {
             //Standard case

--- a/vpr/src/util/vpr_error.cpp
+++ b/vpr/src/util/vpr_error.cpp
@@ -1,6 +1,8 @@
 #include <cstdarg>
+#include <string>
 
 #include "vtr_util.h"
+#include "vtr_log.h"
 #include "vpr_error.h"
 
 /* Date:June 15th, 2013
@@ -11,6 +13,10 @@
  *			anything but throw an exception which will be caught
  *			main.c.
  */
+void map_error_activation_status(std::string function_name) {
+    functions_to_demote.insert(function_name);
+}
+
 void vpr_throw(enum e_vpr_error type,
                const char* psz_file_name,
                unsigned int line_num,
@@ -40,4 +46,39 @@ void vvpr_throw(enum e_vpr_error type,
     std::string msg = vtr::vstring_fmt(psz_message, va_args);
 
     throw VprError(type, msg, psz_file_name, line_num);
+}
+
+void vpr_throw_msg(enum e_vpr_error type,
+                   const char* psz_file_name,
+                   unsigned int line_num,
+                   std::string msg) {
+    throw VprError(type, msg, psz_file_name, line_num);
+}
+
+void vpr_throw_opt(enum e_vpr_error type,
+                   const char* psz_func_name,
+                   const char* psz_file_name,
+                   unsigned int line_num,
+                   const char* psz_message,
+                   ...) {
+    std::string func_name(psz_func_name);
+
+    // Make a variable argument list
+    va_list va_args;
+
+    // Initialize variable argument list
+    va_start(va_args, psz_message);
+
+    //Format the message
+    std::string msg = vtr::vstring_fmt(psz_message, va_args);
+
+    auto result = functions_to_demote.find(func_name);
+    if (result != functions_to_demote.end()) {
+        VTR_LOGFF_WARN(psz_file_name, line_num, psz_func_name, msg.data());
+    } else {
+        vpr_throw_msg(type, psz_file_name, line_num, msg);
+    }
+
+    // Reset variable argument list
+    va_end(va_args);
 }

--- a/vpr/src/util/vpr_error.h
+++ b/vpr/src/util/vpr_error.h
@@ -1,8 +1,11 @@
 #ifndef VPR_ERROR_H
 #define VPR_ERROR_H
 
-#include "vtr_error.h"
 #include <cstdarg>
+#include <string>
+#include <unordered_set>
+
+#include "vtr_error.h"
 
 enum e_vpr_error {
     VPR_ERROR_UNKNOWN = 0,
@@ -45,6 +48,15 @@ class VprError : public vtr::VtrError {
     t_vpr_error_type type_;
 };
 
+// Set of function names for which the VPR_THROW errors are treated
+// as VTR_LOG_WARN
+static std::unordered_set<std::string> functions_to_demote;
+
+// This function is used to save into the functions_to_demote set
+// all the function names which contain VPR_THROW errors that are
+// going to be demoted to be VTR_LOG_WARN
+void map_error_activation_status(std::string function_name);
+
 //VPR error reporting routines
 //
 //Note that we mark these functions with the C++11 attribute 'noreturn'
@@ -52,14 +64,17 @@ class VprError : public vtr::VtrError {
 //reduce false-positive compiler warnings
 [[noreturn]] void vpr_throw(enum e_vpr_error type, const char* psz_file_name, unsigned int line_num, const char* psz_message, ...);
 [[noreturn]] void vvpr_throw(enum e_vpr_error type, const char* psz_file_name, unsigned int line_num, const char* psz_message, va_list args);
+[[noreturn]] void vpr_throw_msg(enum e_vpr_error type, const char* psz_file_name, unsigned int line_num, std::string msg);
+
+void vpr_throw_opt(enum e_vpr_error type, const char* psz_func_name, const char* psz_file_name, unsigned int line_num, const char* psz_message, ...);
 
 /*
  * Macro wrapper around vpr_throw() which automatically
  * specifies file and line number of call site.
  */
-#define VPR_THROW(type, ...)                              \
-    do {                                                  \
-        vpr_throw(type, __FILE__, __LINE__, __VA_ARGS__); \
+#define VPR_THROW(type, ...)                                            \
+    do {                                                                \
+        vpr_throw_opt(type, __func__, __FILE__, __LINE__, __VA_ARGS__); \
     } while (false)
 
 #endif

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -1,6 +1,8 @@
 #include <cstring>
 #include <unordered_set>
 #include <regex>
+#include <algorithm>
+
 using namespace std;
 
 #include "vtr_assert.h"
@@ -18,7 +20,6 @@ using namespace std;
 #include "string.h"
 #include "pack_types.h"
 #include "device_grid.h"
-#include <algorithm>
 
 /* This module contains subroutines that are used in several unrelated parts *
  * of VPR.  They are VPR-specific utility routines.                          */

--- a/vpr/src/util/vpr_utils.h
+++ b/vpr/src/util/vpr_utils.h
@@ -2,7 +2,9 @@
 #define VPR_UTILS_H
 
 #include <vector>
+#include <string>
 #include <regex>
+
 #include "vpr_types.h"
 #include "atom_netlist.h"
 #include "clustered_netlist.h"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed rebase issues

#### Description
<!--- Describe your changes in detail -->
Speed up rr_graph file reading by converting rr_nodes and rr_edges to binary.  This includes:
1) An option to write out a binary file and associated shortened .xml rr_graph that tells vpr to use the binary file for rr_nodes and rr_edges
2) The ability to read rr_graph with binary file

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Reading SymbiFlow rr_graph took 30+ seconds each time which became a significant portion of our pack, place, and route time.  Reading xml is generally slow, so replacing the rr_nodes and rr_edges xml tags (the majority of the file) with a reference to a binary file to read drastically speeds up this reading to ~4 seconds if you do not check the rr_graph.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We ran it on a number of our designs and had exactly the same .net .place and .route with using xml and using binary.

#### Usage

To write rr_graph .bin.xml and .bin (must have .real.xml rr_graph produced before running this): 
$VTR_DIR/vtr-verilog-to-routing/build/vpr/vpr $SYMB_DIR/symbiflow-arch-defs/build/xc7/archs/artix7/devices/xc7a50t-basys3-roi-virt/arch.timing.xml --device xc7a50t-basys3-test $SYMB_DIR/symbiflow-arch-defs/common/wire.eblif --read_rr_graph $SYMB_DIR/symbiflow-arch-defs/build/xc7/archs/artix7/devices/rr_graph_xc7a50t-basys3_test.rr_graph.real.xml --route_chan_width 6 --min_route_chan_width_hint 1 --write_rr_graph $SYMB_DIR/symbiflow-arch-defs/build/xc7/archs/artix7/devices/rr_graph_xc7a50t-basys3_test.rr_graph.real.bin.xml --pack --disable_errors check_unbuffered_edges:check_route --allow_dangling_combinational_nodes on

To read binary rr_graph:
Run VPR as you normally would but point it to your rr_graph .bin.xml file instead of the normal .xml rr_graph

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
