### PR TITLE
vpr: using namespace for connection_box_lookahead map

### DIFF
--- a/vpr/src/route/connection_box_lookahead_map.cpp
+++ b/vpr/src/route/connection_box_lookahead_map.cpp
@@ -409,10 +409,10 @@ static void run_dijkstra(int start_node_ind,
      * expansion queue */
     std::vector<float> node_visited_costs(device_ctx.rr_nodes.size(), -1.0);
     /* a priority queue for expansion */
-    std::priority_queue<PQ_Entry> pq;
+    std::priority_queue<util::PQ_Entry> pq;
 
     /* first entry has no upstream delay or congestion */
-    PQ_Entry first_entry(start_node_ind, UNDEFINED, 0, 0, 0, true);
+    util::PQ_Entry first_entry(start_node_ind, UNDEFINED, 0, 0, 0, true);
 
     pq.push(first_entry);
 
@@ -424,7 +424,7 @@ static void run_dijkstra(int start_node_ind,
 
     /* now do routing */
     while (!pq.empty()) {
-        PQ_Entry current = pq.top();
+        util::PQ_Entry current = pq.top();
         pq.pop();
 
         int node_ind = current.rr_node_ind;

--- a/vpr/src/route/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead_map_utils.cpp
@@ -7,7 +7,7 @@
 /* Number of CLBs I think the average conn. goes. */
 static const int CLB_DIST = 3;
 
-PQ_Entry::PQ_Entry(
+util::PQ_Entry::PQ_Entry(
     int set_rr_node_ind,
     int switch_ind,
     float parent_delay,
@@ -156,10 +156,10 @@ Cost_Entry Expansion_Cost_Entry::get_median_entry() const {
 }
 
 /* iterates over the children of the specified node and selectively pushes them onto the priority queue */
-void expand_dijkstra_neighbours(PQ_Entry parent_entry,
+void expand_dijkstra_neighbours(util::PQ_Entry parent_entry,
                                 std::vector<float>& node_visited_costs,
                                 std::vector<bool>& node_expanded,
-                                std::priority_queue<PQ_Entry>& pq) {
+                                std::priority_queue<util::PQ_Entry>& pq) {
     auto& device_ctx = g_vpr_ctx.device();
 
     int parent_ind = parent_entry.rr_node_ind;
@@ -175,8 +175,8 @@ void expand_dijkstra_neighbours(PQ_Entry parent_entry,
             continue;
         }
 
-        PQ_Entry child_entry(child_node_ind, switch_ind, parent_entry.delay,
-                             parent_entry.R_upstream, parent_entry.congestion_upstream, false);
+        util::PQ_Entry child_entry(child_node_ind, switch_ind, parent_entry.delay,
+                                   parent_entry.R_upstream, parent_entry.congestion_upstream, false);
 
         VTR_ASSERT(child_entry.cost >= 0);
 

--- a/vpr/src/route/router_lookahead_map_utils.h
+++ b/vpr/src/route/router_lookahead_map_utils.h
@@ -115,6 +115,7 @@ class Expansion_Cost_Entry {
     }
 };
 
+namespace util {
 /* a class that represents an entry in the Dijkstra expansion priority queue */
 class PQ_Entry {
   public:
@@ -133,10 +134,11 @@ class PQ_Entry {
         return (this->cost > obj.cost);
     }
 };
+} // namespace util
 
-void expand_dijkstra_neighbours(PQ_Entry parent_entry,
+void expand_dijkstra_neighbours(util::PQ_Entry parent_entry,
                                 std::vector<float>& node_visited_costs,
                                 std::vector<bool>& node_expanded,
-                                std::priority_queue<PQ_Entry>& pq);
+                                std::priority_queue<util::PQ_Entry>& pq);
 
 #endif


### PR DESCRIPTION
This PR is to avoid conflicts in the linker. There is an issue for which `PQ_Entry` is implemented in two different ways and, at compile time, the linker chooses the wrong implementation. The issue is better described in: https://github.com/SymbiFlow/vtr-verilog-to-routing/issues/136.

This PR adds a namespace to the `PQ_Entry` class in the utils file, eliminating the ambiguity between the classes.

This PR merges into `connection_box_cleanup` branch.

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

