### PR TITLE
cluster: fix unclustered_list_head_size

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/vtr-change.md
+++ b/.github/ISSUE_TEMPLATE/vtr-change.md
@@ -1,0 +1,25 @@
+---
+name: VTR change
+about: Describe purpose and lifecycle of a local change we made to VTR
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Why did we need this? (what does this change enable us to do)
+<!--- i.e. what does this change enable us to do? -->
+
+### What did it change?
+<!--- i.e. technical description what the change does -->
+
+### Should it be merged upstream - if not, when can we delete it?
+
+### What is needed to get this merged / deleted? 
+
+* [ ] is the implementation work to make suitable for merging / deletion completed?
+* [ ] Is there an associated test? <!--- i.e. how will we prevent it from regressing? -->
+* [ ] is this currently part of the Conda package?
+* [ ] is this properly cleaned up in our local repositories? <!--- add subtasks here if needed) -->
+
+### Tracker / branch / PR & other useful links

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ option(VTR_ENABLE_SANITIZE "Enable address/leak/undefined-behaviour sanitizers (
 option(VTR_ENABLE_PROFILING "Enable performance profiler (gprof)" OFF)
 option(VTR_ENABLE_COVERAGE "Enable code coverage tracking (gcov)" OFF)
 option(VTR_ENABLE_DEBUG_LOGGING "Enable debug logging" OFF)
+option(VTR_ENABLE_CAPNPROTO "Enable capnproto binary serialization support in VPR." ON)
 
 #Allow the user to decide weather to compile the graphics library
 set(VPR_USE_EZGL "auto" CACHE STRING "Specify whether vpr uses the graphics library")
@@ -269,8 +270,13 @@ endif()
 #
 # Set final flags
 #
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARN_FLAGS} ${SANITIZE_FLAGS} ${PROFILING_FLAGS} ${COVERAGE_FLAGS} ${LOGGING_FLAGS} ${COLORED_COMPILE}")
-message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+separate_arguments(
+    ADDITIONAL_FLAGS UNIX_COMMAND "${SANITIZE_FLAGS} ${PROFILING_FLAGS} ${COVERAGE_FLAGS} ${LOGGING_FLAGS} ${COLORED_COMPILE}"
+    )
+add_compile_options(${ADDITIONAL_FLAGS})
+separate_arguments(
+    WARN_FLAGS UNIX_COMMAND "${WARN_FLAGS}"
+    )
 
 
 #
@@ -322,6 +328,9 @@ endif()
 
 #Add the various sub-projects
 add_subdirectory(libs)
+
+# Only add warn flags for VPR internal libraries.
+add_compile_options(${WARN_FLAGS})
 add_subdirectory(vpr)
 add_subdirectory(abc)
 add_subdirectory(ODIN_II)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
+
+SymbiFlow WIP changes for Verilog to Routing (VTR)
+==================================================
+
+This branch contains work in progress changes for using Verilog to Routing
+(VTR) as part of SymbiFlow.
+
+---
+
 # Verilog to Routing (VTR)
-[![Build Status](https://travis-ci.org/verilog-to-routing/vtr-verilog-to-routing.svg?branch=master)](https://travis-ci.org/verilog-to-routing/vtr-verilog-to-routing) [![Documentation Status](https://readthedocs.org/projects/vtr/badge/?version=latest)](http://docs.verilogtorouting.org/en/latest/?badge=latest)
+[![Build Status](https://travis-ci.com/SymbiFlow/vtr-verilog-to-routing.svg?branch=master)](https://travis-ci.com/SymbiFlow/vtr-verilog-to-routing) [![Documentation Status](https://readthedocs.org/projects/vtr/badge/?version=latest)](http://docs.verilogtorouting.org/en/latest/?badge=latest)
 
 ## Introduction
 The Verilog-to-Routing (VTR) project is a world-wide collaborative effort to provide a open-source framework for conducting FPGA architecture and CAD research and development.

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,10 +1,15 @@
-#VTR developed libraries
+#Externally developed libraries
+add_subdirectory(EXTERNAL)
+
+# VTR developed libraries
+#  Only add warn flags for VPR internal libraries.
+add_compile_options(${WARN_FLAGS})
 add_subdirectory(libarchfpga)
 add_subdirectory(libvtrutil)
 add_subdirectory(liblog)
 add_subdirectory(libpugiutil)
 add_subdirectory(libeasygl)
 add_subdirectory(librtlnumber)
-
-#Externally developed libraries
-add_subdirectory(EXTERNAL)
+if(${VTR_ENABLE_CAPNPROTO})
+    add_subdirectory(libvtrcapnproto)
+endif()

--- a/libs/EXTERNAL/CMakeLists.txt
+++ b/libs/EXTERNAL/CMakeLists.txt
@@ -8,8 +8,25 @@ add_subdirectory(libsdcparse)
 add_subdirectory(libblifparse)
 add_subdirectory(libtatum)
 
-#VPR_USE_EZGL is initialized in the root CMakeLists. 
+# Override default policy for capnproto and libezgl (CMake policy version 3.1)
+# Enable new IPO variables
+set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
+
+#VPR_USE_EZGL is initialized in the root CMakeLists.
 #compile libezgl only if the user asks for or has its dependencies installed.
 if(VPR_USE_EZGL STREQUAL "on")
     add_subdirectory(libezgl)
+endif()
+
+if(${VTR_ENABLE_CAPNPROTO})
+    # Enable option overrides via variables
+    set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
+    # Re-enable CXX extensions for capnproto.
+    set(CMAKE_CXX_EXTENSIONS ON)
+
+    # Disable capnproto tests
+    set(BUILD_TESTING OFF)
+
+    add_subdirectory(capnproto EXCLUDE_FROM_ALL)
 endif()

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -1202,6 +1202,10 @@ struct t_segment_inf {
     //float Cmetal_per_m; /* Wire capacitance (per meter) */
 };
 
+inline bool operator==(const t_segment_inf& a, const t_segment_inf& b) {
+    return a.name == b.name && a.frequency == b.frequency && a.length == b.length && a.arch_wire_switch == b.arch_wire_switch && a.arch_opin_switch == b.arch_opin_switch && a.frac_cb == b.frac_cb && a.frac_sb == b.frac_sb && a.longline == b.longline && a.Rmetal == b.Rmetal && a.Cmetal == b.Cmetal && a.directionality == b.directionality && a.cb == b.cb && a.sb == b.sb;
+}
+
 enum class SwitchType {
     MUX = 0,   //A configurable (buffered) mux (single-driver)
     TRISTATE,  //A configurable tristate-able buffer (multi-driver)

--- a/libs/libvtrcapnproto/CMakeLists.txt
+++ b/libs/libvtrcapnproto/CMakeLists.txt
@@ -1,0 +1,40 @@
+if(NOT MSCV)
+    # These flags generate noisy but non-bug warnings when using lib kj,
+    # supress them.
+    set(WARN_FLAGS_TO_DISABLE
+        -Wno-undef
+        -Wno-non-virtual-dtor
+        )
+    foreach(flag ${WARN_FLAGS_TO_DISABLE})
+        CHECK_CXX_COMPILER_FLAG(${flag} CXX_COMPILER_SUPPORTS_${flag})
+        if(CXX_COMPILER_SUPPORTS_${flag})
+            #Flag supported, so enable it
+            add_compile_options(${flag})
+        endif()
+    endforeach()
+endif()
+
+# Create generated headers from capnp schema files
+#
+# Each schema used should appear here.
+capnp_generate_cpp(CAPNP_SRCS CAPNP_HDRS
+    place_delay_model.capnp
+    connection_map.capnp
+    matrix.capnp
+    )
+
+add_library(libvtrcapnproto STATIC
+            ${CAPNP_SRCS}
+            mmap_file.h
+            mmap_file.cpp
+            serdes_utils.h
+            serdes_utils.cpp
+            )
+target_include_directories(libvtrcapnproto PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+    )
+target_link_libraries(libvtrcapnproto
+    libvtrutil
+    CapnProto::capnp
+    )

--- a/libs/libvtrcapnproto/README.md
+++ b/libs/libvtrcapnproto/README.md
@@ -1,0 +1,84 @@
+Capnproto usage in VTR
+======================
+
+Capnproto is a data serialization framework designed for portabliity and speed.
+In VPR, capnproto is used to provide binary formats for internal data
+structures that can be computed once, and used many times.  Specific examples:
+ - rrgraph
+ - Router lookahead data
+ - Place matrix delay estimates
+
+What is capnproto?
+==================
+
+capnproto can be broken down into 3 parts:
+ - A schema language
+ - A code generator
+ - A library
+
+The schema language is used to define messages.  Each message must have an
+explcit capnproto schema, which are stored in files suffixed with ".capnp".
+The capnproto documentation for how to write these schema files can be found
+here: https://capnproto.org/language.html
+
+The schema by itself is not especially useful.  In order to read and write
+messages defined by the schema in a target language (e.g. C++), a code
+generation step is required.  Capnproto provides a cmake function for this
+purpose, `capnp_generate_cpp`.  This generates C++ source and header files.
+These source and header files combined with the capnproto C++ library, enables
+C++ code to read and write the messages matching a particular schema.  The C++
+library API can be found here: https://capnproto.org/cxx.html
+
+Contents of libvtrcapnproto
+===========================
+
+libvtrcapnproto should contain two elements:
+ - Utilities for working capnproto messages in VTR
+ - Generate source and header files of all capnproto messages used in VTR
+
+I/O Utilities
+-------------
+
+Capnproto does not provide IO support, instead it works from arrays (or file
+descriptors).  To avoid re-writing this code, libvtrcapnproto provides two
+utilities that should be used whenever reading or writing capnproto message to
+disk:
+ - `serdes_utils.h` provides the writeMessageToFile function - Writes a
+   capnproto message to disk.
+ - `mmap_file.h` provides MmapFile object - Maps a capnproto message from the
+   disk as a flat array.
+
+NdMatrix Utilities
+------------------
+
+A common datatype which appears in many data structures that VPR might want to
+serialize is the generic type `vtr::NdMatrix`.  `ndmatrix_serdes.h` provides
+generic functions ToNdMatrix and FromNdMatrix, which can be used to generically
+convert between the provideid capnproto message `Matrix` and `vtr::NdMatrix`.
+
+Capnproto schemas
+-----------------
+
+libvtrcapnproto should contain all capnproto schema definitions used within
+VTR.  To add a new schema:
+1. Add the schema to git in `libs/libvtrcapnproto/`
+2. Add the schema file name to `capnp_generate_cpp` invocation in
+   `libs/libvtrcapnproto/CMakeLists.txt`.
+
+The schema will be available in the header file `schema filename>.h`.  The
+actual header file will appear in the CMake build directory
+`libs/libvtrcapnproto` after `libvtrcapnproto` has been rebuilt.
+
+Writing capnproto binary files to text
+======================================
+
+The `capnp` tool (found in the CMake build directiory
+`libs/EXTERNAL/capnproto/c++/src/capnp`) can be used to convert from a binary
+capnp message to a textual form.
+
+Example converting VprOverrideDelayModel from binary to text:
+
+```
+capnp convert binary:text place_delay_model.capnp VprOverrideDelayModel \
+  < place_delay.bin > place_delay.txt
+```

--- a/libs/libvtrcapnproto/connection_map.capnp
+++ b/libs/libvtrcapnproto/connection_map.capnp
@@ -1,0 +1,19 @@
+@0x876ec83c2fea5a18;
+
+using Matrix = import "matrix.capnp";
+
+struct VprCostEntry {
+    delay @0 :Float32;
+    congestion @1 :Float32;
+}
+
+struct VprVector2D {
+    x @0 :Int64;
+    y @1 :Int64;
+}
+
+struct VprCostMap {
+    costMap @0 :List(Matrix.Matrix(VprCostEntry));
+    offset @1 :List(VprVector2D);
+    segmentMap @2 :List(Int64);
+}

--- a/libs/libvtrcapnproto/matrix.capnp
+++ b/libs/libvtrcapnproto/matrix.capnp
@@ -1,0 +1,9 @@
+@0xafffc9c1f309bc00;
+
+struct Matrix(Value) {
+    struct Entry {
+        value @0 :Value;
+    }
+    dims @0 :List(Int64);
+    data @1 :List(Entry);
+}

--- a/libs/libvtrcapnproto/mmap_file.cpp
+++ b/libs/libvtrcapnproto/mmap_file.cpp
@@ -1,0 +1,37 @@
+#include "mmap_file.h"
+#include "vtr_error.h"
+#include "vtr_util.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "kj/filesystem.h"
+
+MmapFile::MmapFile(const std::string& file)
+    : size_(0) {
+    try {
+        auto fs = kj::newDiskFilesystem();
+        auto path = fs->getCurrentPath().evalNative(file);
+
+        const auto& dir = fs->getRoot();
+        auto stat = dir.lstat(path);
+        auto f = dir.openFile(path);
+        size_ = stat.size;
+        data_ = f->mmap(0, stat.size);
+    } catch (kj::Exception& e) {
+        throw vtr::VtrError(e.getDescription().cStr(), e.getFile(), e.getLine());
+    }
+}
+
+const kj::ArrayPtr<const ::capnp::word> MmapFile::getData() const {
+    if ((size_ % sizeof(::capnp::word)) != 0) {
+        throw vtr::VtrError(
+            vtr::string_fmt("size_ %d is not a multiple of capnp::word", size_),
+            __FILE__, __LINE__);
+    }
+
+    return kj::arrayPtr(reinterpret_cast<const ::capnp::word*>(data_.begin()),
+                        size_ / sizeof(::capnp::word));
+}

--- a/libs/libvtrcapnproto/mmap_file.h
+++ b/libs/libvtrcapnproto/mmap_file.h
@@ -1,0 +1,19 @@
+#ifndef MMAP_FILE_H_
+#define MMAP_FILE_H_
+
+#include <string>
+#include "capnp/message.h"
+#include "kj/array.h"
+
+// Platform independent mmap, useful for reading large capnp's.
+class MmapFile {
+  public:
+    explicit MmapFile(const std::string& file);
+    const kj::ArrayPtr<const ::capnp::word> getData() const;
+
+  private:
+    size_t size_;
+    kj::Array<const kj::byte> data_;
+};
+
+#endif /* MMAP_FILE_H_ */

--- a/libs/libvtrcapnproto/ndmatrix_serdes.h
+++ b/libs/libvtrcapnproto/ndmatrix_serdes.h
@@ -1,0 +1,87 @@
+#ifndef NDMATRIX_SERDES_H_
+#define NDMATRIX_SERDES_H_
+
+#include <functional>
+#include "vtr_ndmatrix.h"
+#include "vpr_error.h"
+#include "matrix.capnp.h"
+
+// Generic function to convert from Matrix capnproto message to vtr::NdMatrix.
+//
+// Template arguments:
+//  N = Number of matrix dimensions, must be fixed.
+//  CapType = Source capnproto message type that is a single element the
+//            Matrix capnproto message.
+//  CType = Target C++ type that is a single element of vtr::NdMatrix.
+//
+// Arguments:
+//  m_out = Target vtr::NdMatrix.
+//  m_in = Source capnproto message reader.
+//  copy_fun = Function to convert from CapType to CType.
+//
+template<size_t N, typename CapType, typename CType>
+void ToNdMatrix(
+    vtr::NdMatrix<CType, N>* m_out,
+    const typename Matrix<CapType>::Reader& m_in,
+    const std::function<void(CType*, const typename CapType::Reader&)>& copy_fun) {
+    const auto& dims = m_in.getDims();
+    if (N != dims.size()) {
+        VPR_THROW(VPR_ERROR_OTHER,
+                  "Wrong dimension of template N = %zu, m_in.getDims() = %zu",
+                  N, dims.size());
+    }
+
+    std::array<size_t, N> dim_sizes;
+    size_t required_elements = 1;
+    for (size_t i = 0; i < N; ++i) {
+        dim_sizes[i] = dims[i];
+        required_elements *= dims[i];
+    }
+    m_out->resize(dim_sizes);
+
+    const auto& data = m_in.getData();
+    if (data.size() != required_elements) {
+        VPR_THROW(VPR_ERROR_OTHER,
+                  "Wrong number of elements, expected %zu, actual %zu",
+                  required_elements, data.size());
+    }
+
+    for (size_t i = 0; i < required_elements; ++i) {
+        copy_fun(&m_out->get(i), data[i].getValue());
+    }
+}
+
+// Generic function to convert from vtr::NdMatrix to Matrix capnproto message.
+//
+// Template arguments:
+//  N = Number of matrix dimensions, must be fixed.
+//  CapType = Target capnproto message type that is a single element the
+//            Matrix capnproto message.
+//  CType = Source C++ type that is a single element of vtr::NdMatrix.
+//
+// Arguments:
+//  m_out = Target capnproto message builder.
+//  m_in = Source vtr::NdMatrix.
+//  copy_fun = Function to convert from CType to CapType.
+//
+template<size_t N, typename CapType, typename CType>
+void FromNdMatrix(
+    typename Matrix<CapType>::Builder* m_out,
+    const vtr::NdMatrix<CType, N>& m_in,
+    const std::function<void(typename CapType::Builder*, const CType&)>& copy_fun) {
+    size_t elements = 1;
+    auto dims = m_out->initDims(N);
+    for (size_t i = 0; i < N; ++i) {
+        dims.set(i, m_in.dim_size(i));
+        elements *= dims[i];
+    }
+
+    auto data = m_out->initData(elements);
+
+    for (size_t i = 0; i < elements; ++i) {
+        auto elem = data[i].getValue();
+        copy_fun(&elem, m_in.get(i));
+    }
+}
+
+#endif /* NDMATRIX_SERDES_H_ */

--- a/libs/libvtrcapnproto/place_delay_model.capnp
+++ b/libs/libvtrcapnproto/place_delay_model.capnp
@@ -1,0 +1,26 @@
+@0xfee98b707b92aa09;
+
+using Matrix = import "matrix.capnp";
+
+struct VprFloatEntry {
+    value @0 :Float32;
+}
+struct VprDeltaDelayModel {
+    delays @0 :Matrix.Matrix(VprFloatEntry);
+}
+
+struct VprOverrideEntry {
+    fromType @0 :Int16;
+    toType @1 :Int16;
+    fromClass @2 :Int16;
+    toClass @3 :Int16;
+    deltaX @4 :Int16;
+    deltaY @5 :Int16;
+
+    delay @6 :Float32;
+}
+
+struct VprOverrideDelayModel {
+    delays @0 :Matrix.Matrix(VprFloatEntry);
+    delayOverrides @1 :List(VprOverrideEntry);
+}

--- a/libs/libvtrcapnproto/serdes_utils.cpp
+++ b/libs/libvtrcapnproto/serdes_utils.cpp
@@ -1,0 +1,22 @@
+#include "serdes_utils.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "vtr_error.h"
+#include "kj/filesystem.h"
+
+void writeMessageToFile(const std::string& file, ::capnp::MessageBuilder* builder) {
+    try {
+        auto fs = kj::newDiskFilesystem();
+        auto path = fs->getCurrentPath().evalNative(file);
+
+        const auto& dir = fs->getRoot();
+        auto f = dir.openFile(path, kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
+        f->truncate(0);
+        auto f_app = kj::newFileAppender(std::move(f));
+        capnp::writeMessage(*f_app, *builder);
+    } catch (kj::Exception& e) {
+        throw vtr::VtrError(e.getDescription().cStr(), e.getFile(), e.getLine());
+    }
+}

--- a/libs/libvtrcapnproto/serdes_utils.h
+++ b/libs/libvtrcapnproto/serdes_utils.h
@@ -1,0 +1,11 @@
+#ifndef SERDES_UTILS_H_
+#define SERDES_UTILS_H_
+
+#include <string>
+#include "capnp/serialize.h"
+
+// Platform indepedent way to file message to a file on disk.
+void writeMessageToFile(const std::string& file,
+        ::capnp::MessageBuilder* builder);
+
+#endif /* SERDES_UTILS_H_ */

--- a/libs/libvtrutil/src/vtr_flat_map.h
+++ b/libs/libvtrutil/src/vtr_flat_map.h
@@ -85,7 +85,7 @@ class flat_map {
     }
 
     //direct vector constructor
-    explicit flat_map(std::vector<value_type>&& values) {
+    flat_map(std::vector<value_type>&& values) {
         //By moving the values this should be more efficient
         //than the range constructor which must copy each element
         vec_ = std::move(values);

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -41,8 +41,13 @@ file(GLOB_RECURSE LIB_SOURCES src/*/*.cpp)
 file(GLOB_RECURSE LIB_HEADERS src/*/*.h)
 files_to_dirs(LIB_HEADERS LIB_INCLUDE_DIRS)
 
+if(${VTR_ENABLE_CAPNPROTO})
+    add_definitions("-DVTR_ENABLE_CAPNPROTO")
+endif()
+
 #Create the library
 add_library(libvpr STATIC
+             ${CAPNP_SRCS}
              ${LIB_HEADERS}
              ${LIB_SOURCES}
 )
@@ -56,14 +61,19 @@ target_link_libraries(libvpr
                         libarchfpga
                         libsdcparse
                         libblifparse
-			libeasygl
+                        libeasygl
                         libtatum
                         libargparse
-                        libpugixml)
+                        libpugixml
+                        )
+
+if(${VTR_ENABLE_CAPNPROTO})
+    target_link_libraries(libvpr libvtrcapnproto)
+endif()
 
 #link graphics library only when graphics set to on
 if (VPR_USE_EZGL STREQUAL "on")
-    target_link_libraries(libvpr 
+    target_link_libraries(libvpr
 			     ezgl)
 
     compile_gresources(

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -347,8 +347,8 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
     RouterOpts->max_convergence_count = Options.router_max_convergence_count;
     RouterOpts->reconvergence_cpd_threshold = Options.router_reconvergence_cpd_threshold;
     RouterOpts->first_iteration_timing_report_file = Options.router_first_iteration_timing_report_file;
-
     RouterOpts->strict_checks = Options.strict_checks;
+    RouterOpts->disable_check_route = Options.disable_check_route;
 }
 
 static void SetupAnnealSched(const t_options& Options,

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -349,6 +349,9 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
     RouterOpts->first_iteration_timing_report_file = Options.router_first_iteration_timing_report_file;
 
     RouterOpts->strict_checks = Options.strict_checks;
+
+    RouterOpts->write_router_lookahead = Options.write_router_lookahead;
+    RouterOpts->read_router_lookahead = Options.read_router_lookahead;
 }
 
 static void SetupAnnealSched(const t_options& Options,
@@ -478,6 +481,9 @@ static void SetupPlacerOpts(const t_options& Options, t_placer_opts* PlacerOpts)
     PlacerOpts->move_stats_file = Options.place_move_stats_file;
 
     PlacerOpts->strict_checks = Options.strict_checks;
+
+    PlacerOpts->write_placement_delay_lookup = Options.write_placement_delay_lookup;
+    PlacerOpts->read_placement_delay_lookup = Options.read_placement_delay_lookup;
 }
 
 static void SetupAnalysisOpts(const t_options& Options, t_analysis_opts& analysis_opts) {

--- a/vpr/src/base/echo_files.cpp
+++ b/vpr/src/base/echo_files.cpp
@@ -112,6 +112,8 @@ void alloc_and_load_echo_file_info() {
     setEchoFileName(E_ECHO_CHAN_DETAILS, "chan_details.txt");
     setEchoFileName(E_ECHO_SBLOCK_PATTERN, "sblock_pattern.txt");
     setEchoFileName(E_ECHO_ENDPOINT_TIMING, "endpoint_timing.echo.json");
+
+    setEchoFileName(E_ECHO_LOOKAHEAD_MAP, "lookahead_map.echo");
 }
 
 void free_echo_file_info() {

--- a/vpr/src/base/echo_files.h
+++ b/vpr/src/base/echo_files.h
@@ -43,6 +43,7 @@ enum e_echo_files {
     E_ECHO_CHAN_DETAILS,
     E_ECHO_SBLOCK_PATTERN,
     E_ECHO_ENDPOINT_TIMING,
+    E_ECHO_LOOKAHEAD_MAP,
 
     //Timing Graphs
     E_ECHO_PRE_PACKING_TIMING_GRAPH,

--- a/vpr/src/base/place_and_route.cpp
+++ b/vpr/src/base/place_and_route.cpp
@@ -351,7 +351,6 @@ int binary_search_place_and_route(t_placer_opts placer_opts,
                     router_opts.trim_empty_channels,
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
-                    router_opts.lookahead_type,
                     arch->Directs, arch->num_directs,
                     &warnings);
 

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -648,6 +648,8 @@ struct ParseRouterLookahead {
             conv_value.set_value(e_router_lookahead::CLASSIC);
         else if (str == "map")
             conv_value.set_value(e_router_lookahead::MAP);
+        else if (str == "connection_box_map")
+            conv_value.set_value(e_router_lookahead::CONNECTION_BOX_MAP);
         else {
             std::stringstream msg;
             msg << "Invalid conversion from '"
@@ -661,17 +663,22 @@ struct ParseRouterLookahead {
 
     ConvertedValue<std::string> to_str(e_router_lookahead val) {
         ConvertedValue<std::string> conv_value;
-        if (val == e_router_lookahead::CLASSIC)
+        if (val == e_router_lookahead::CLASSIC) {
             conv_value.set_value("classic");
-        else {
-            VTR_ASSERT(val == e_router_lookahead::MAP);
+        } else if (val == e_router_lookahead::MAP) {
             conv_value.set_value("map");
+        } else if (val == e_router_lookahead::CONNECTION_BOX_MAP) {
+            conv_value.set_value("connection_box_map");
+        } else {
+            std::stringstream msg;
+            msg << "Unrecognized e_router_lookahead";
+            conv_value.set_error(msg.str());
         }
         return conv_value;
     }
 
     std::vector<std::string> default_choices() {
-        return {"classic", "map"};
+        return {"classic", "map", "connection_box_map"};
     }
 };
 
@@ -1004,6 +1011,24 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
     file_grp.add_argument(args.write_rr_graph_file, "--write_rr_graph")
         .help("Writes the routing resource graph to the specified file")
         .metavar("RR_GRAPH_FILE")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    file_grp.add_argument(args.read_router_lookahead, "--read_router_lookahead")
+        .help(
+            "Reads the lookahead data from the specified file instead of computing it.")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    file_grp.add_argument(args.write_router_lookahead, "--write_router_lookahead")
+        .help("Writes the lookahead data to the specified file.")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    file_grp.add_argument(args.read_placement_delay_lookup, "--read_placement_delay_lookup")
+        .help(
+            "Reads the placement delay lookup from the specified file instead of computing it.")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    file_grp.add_argument(args.write_placement_delay_lookup, "--write_placement_delay_lookup")
+        .help("Writes the placement delay lookup to the specified file.")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     file_grp.add_argument(args.out_file_prefix, "--outfile_prefix")

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1575,6 +1575,11 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    route_timing_grp.add_argument<bool, ParseOnOff>(args.disable_check_route, "--disable_check_route")
+        .help("Disables check_route once routing step has finished or when routing file is loaded")
+        .default_value("off")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     route_timing_grp.add_argument(args.router_debug_net, "--router_debug_net")
         .help(
             "Controls when router debugging is enabled.\n"

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -124,6 +124,7 @@ struct t_options {
     argparse::ArgValue<bool> verify_binary_search;
     argparse::ArgValue<e_router_algorithm> RouterAlgorithm;
     argparse::ArgValue<int> min_incremental_reroute_fanout;
+    argparse::ArgValue<bool> disable_check_route;
 
     /* Timing-driven router options only */
     argparse::ArgValue<float> astar_fac;

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -27,6 +27,12 @@ struct t_options {
     argparse::ArgValue<std::string> write_rr_graph_file;
     argparse::ArgValue<std::string> read_rr_graph_file;
 
+    argparse::ArgValue<std::string> write_placement_delay_lookup;
+    argparse::ArgValue<std::string> read_placement_delay_lookup;
+
+    argparse::ArgValue<std::string> write_router_lookahead;
+    argparse::ArgValue<std::string> read_router_lookahead;
+
     /* Stage Options */
     argparse::ArgValue<bool> do_packing;
     argparse::ArgValue<bool> do_placement;

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -824,7 +824,6 @@ void vpr_create_rr_graph(t_vpr_setup& vpr_setup, const t_arch& arch, int chan_wi
                     router_opts.trim_empty_channels,
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
-                    router_opts.lookahead_type,
                     arch.Directs, arch.num_directs,
                     &warnings);
     //Initialize drawing, now that we have an RR graph

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -676,7 +676,9 @@ RouteStatus vpr_route_flow(t_vpr_setup& vpr_setup, const t_arch& arch) {
         std::string graphics_msg;
         if (route_status.success()) {
             //Sanity check the routing
-            check_route(router_opts.route_type);
+            if (!router_opts.disable_check_route) {
+                check_route(router_opts.route_type);
+            }
             get_serial_num();
 
             //Update status

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -19,7 +19,9 @@
 #include "clock_network_builders.h"
 #include "clock_connection_builders.h"
 #include "route_traceback.h"
+#include "router_lookahead.h"
 #include "place_macro.h"
+#include "connection_box.h"
 
 //A Context is collection of state relating to a particular part of VPR
 //
@@ -194,6 +196,8 @@ struct DeviceContext : public Context {
      * Clock Network
      ********************************************************************/
     t_clock_arch* clock_arch;
+
+    ConnectionBoxes connection_boxes;
 };
 
 //State relating to power analysis
@@ -271,6 +275,14 @@ struct RoutingContext : public Context {
 
     //SHA256 digest of the .route file (used for unique identification and consistency checking)
     std::string routing_id;
+
+    // Cache of router lookahead object.
+    std::unique_ptr<RouterLookahead> cached_router_lookahead_;
+
+    // Parameters used for cached router lookahead object.
+    e_router_lookahead cached_router_lookahead_type_;
+    std::string cached_lookahead_file_;
+    std::vector<t_segment_inf> cached_segment_inf_;
 };
 
 //This object encapsulates VPR's state. There is typically a single instance which is

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -103,7 +103,10 @@ constexpr const char* EMPTY_BLOCK_NAME = "EMPTY";
 enum class e_router_lookahead {
     CLASSIC, //VPR's classic lookahead (assumes uniform wire types)
     MAP,     //Lookahead considering different wire types (see Oleg Petelin's MASc Thesis)
-    NO_OP    //A no-operation lookahead which always returns zero
+    NO_OP,   //A no-operation lookahead which always returns zero
+    CONNECTION_BOX_MAP,
+    // Lookahead considering different wire types and IPIN
+    // connection box.
 };
 
 enum class e_route_bb_update {
@@ -821,6 +824,9 @@ struct t_placer_opts {
     std::string post_place_timing_report_file;
 
     bool strict_checks;
+
+    std::string write_placement_delay_lookup;
+    std::string read_placement_delay_lookup;
 };
 
 /* All the parameters controlling the router's operation are in this        *
@@ -952,6 +958,9 @@ struct t_router_opts {
     float reconvergence_cpd_threshold;
     std::string first_iteration_timing_report_file;
     bool strict_checks;
+
+    std::string write_router_lookahead;
+    std::string read_router_lookahead;
 };
 
 struct t_analysis_opts {

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -952,6 +952,7 @@ struct t_router_opts {
     float reconvergence_cpd_threshold;
     std::string first_iteration_timing_report_file;
     bool strict_checks;
+    bool disable_check_route;
 };
 
 struct t_analysis_opts {

--- a/vpr/src/pack/cluster.cpp
+++ b/vpr/src/pack/cluster.cpp
@@ -870,7 +870,7 @@ static void alloc_and_init_clustering(const t_molecule_stats& max_molecule_stats
 
     /* alloc and load list of molecules to pack */
     unclustered_list_head = (t_molecule_link*)vtr::calloc(max_molecule_stats.num_used_ext_inputs + 1, sizeof(t_molecule_link));
-    unclustered_list_head_size = max_molecule_stats.num_used_ext_inputs;
+    unclustered_list_head_size = max_molecule_stats.num_used_ext_inputs + 1;
 
     for (int i = 0; i <= max_molecule_stats.num_used_ext_inputs; i++) {
         unclustered_list_head[i].next = nullptr;

--- a/vpr/src/place/place_delay_model.cpp
+++ b/vpr/src/place/place_delay_model.cpp
@@ -8,6 +8,15 @@
 
 #include "vtr_log.h"
 #include "vtr_math.h"
+#include "vpr_error.h"
+
+#ifdef VTR_ENABLE_CAPNPROTO
+#    include "capnp/serialize.h"
+#    include "place_delay_model.capnp.h"
+#    include "ndmatrix_serdes.h"
+#    include "mmap_file.h"
+#    include "serdes_utils.h"
+#endif /* VTR_ENABLE_CAPNPROTO */
 
 /*
  * DeltaDelayModel
@@ -110,3 +119,178 @@ void OverrideDelayModel::dump_echo(std::string filepath) const {
 
     vtr::fclose(f);
 }
+
+float OverrideDelayModel::get_delay_override(int from_type, int from_class, int to_type, int to_class, int delta_x, int delta_y) const {
+    t_override key;
+    key.from_type = from_type;
+    key.from_class = from_class;
+    key.to_type = to_type;
+    key.to_class = to_class;
+    key.delta_x = delta_x;
+    key.delta_y = delta_y;
+
+    auto iter = delay_overrides_.find(key);
+    if (iter == delay_overrides_.end()) {
+        VPR_THROW(VPR_ERROR_PLACE, "Key not found.");
+    }
+    return iter->second;
+}
+
+const DeltaDelayModel* OverrideDelayModel::base_delay_model() const {
+    return base_delay_model_.get();
+}
+
+void OverrideDelayModel::set_base_delay_model(std::unique_ptr<DeltaDelayModel> base_delay_model) {
+    base_delay_model_ = std::move(base_delay_model);
+}
+
+// When writing capnp targetted serialization, always allow compilation when
+// VTR_ENABLE_CAPNPROTO=OFF.  Generally this means throwing an exception
+// instead.
+//
+#ifndef VTR_ENABLE_CAPNPROTO
+
+#    define DISABLE_ERROR                              \
+        "is disable because VTR_ENABLE_CAPNPROTO=OFF." \
+        "Re-compile with CMake option VTR_ENABLE_CAPNPROTO=ON to enable."
+
+void DeltaDelayModel::read(const std::string& /*file*/) {
+    VPR_THROW(VPR_ERROR_PLACE, "DeltaDelayModel::read " DISABLE_ERROR);
+}
+
+void DeltaDelayModel::write(const std::string& /*file*/) const {
+    VPR_THROW(VPR_ERROR_PLACE, "DeltaDelayModel::write " DISABLE_ERROR);
+}
+
+void OverrideDelayModel::read(const std::string& /*file*/) {
+    VPR_THROW(VPR_ERROR_PLACE, "OverrideDelayModel::read " DISABLE_ERROR);
+}
+
+void OverrideDelayModel::write(const std::string& /*file*/) const {
+    VPR_THROW(VPR_ERROR_PLACE, "OverrideDelayModel::write " DISABLE_ERROR);
+}
+
+#else /* VTR_ENABLE_CAPNPROTO */
+
+static void ToFloat(float* out, const VprFloatEntry::Reader& in) {
+    // Getting a scalar field is always "get<field name>()".
+    *out = in.getValue();
+}
+
+static void FromFloat(VprFloatEntry::Builder* out, const float& in) {
+    // Setting a scalar field is always "set<field name>(value)".
+    out->setValue(in);
+}
+
+void DeltaDelayModel::read(const std::string& file) {
+    // MmapFile object creates an mmap of the specified path, and will munmap
+    // when the object leaves scope.
+    MmapFile f(file);
+
+    // FlatArrayMessageReader is used to read the message from the data array
+    // provided by MmapFile.
+    ::capnp::FlatArrayMessageReader reader(f.getData());
+
+    // When reading capnproto files the Reader object to use is named
+    // <schema name>::Reader.
+    //
+    // Initially this object is an empty VprDeltaDelayModel.
+    VprDeltaDelayModel::Reader model;
+
+    // The reader.getRoot performs a cast from the generic capnproto to fit
+    // with the specified schema.
+    //
+    // Note that capnproto does not validate that the incoming data matches the
+    // schema.  If this property is required, some form of check would be
+    // required.
+    model = reader.getRoot<VprDeltaDelayModel>();
+
+    // ToNdMatrix is a generic function for converting a Matrix capnproto
+    // to a vtr::NdMatrix.
+    //
+    // The use must supply the matrix dimension (2 in this case), the source
+    // capnproto type (VprFloatEntry),
+    // target C++ type (flat), and a function to convert from the source capnproto
+    // type to the target C++ type (ToFloat).
+    //
+    // The second argument should be of type Matrix<X>::Reader where X is the
+    // capnproto element type.
+    ToNdMatrix<2, VprFloatEntry, float>(&delays_, model.getDelays(), ToFloat);
+}
+
+void DeltaDelayModel::write(const std::string& file) const {
+    // MallocMessageBuilder object is the generate capnproto message builder,
+    // using malloc for buffer allocation.
+    ::capnp::MallocMessageBuilder builder;
+
+    // initRoot<X> returns a X::Builder object that can be used to set the
+    // fields in the message.
+    auto model = builder.initRoot<VprDeltaDelayModel>();
+
+    // FromNdMatrix is a generic function for converting a vtr::NdMatrix to a
+    // Matrix message.  It is the mirror function of ToNdMatrix described in
+    // read above.
+    auto delays = model.getDelays();
+    FromNdMatrix<2, VprFloatEntry, float>(&delays, delays_, FromFloat);
+
+    // writeMessageToFile writes message to the specified file.
+    writeMessageToFile(file, &builder);
+}
+
+void OverrideDelayModel::read(const std::string& file) {
+    MmapFile f(file);
+    ::capnp::FlatArrayMessageReader reader(f.getData());
+
+    vtr::Matrix<float> delays;
+    auto model = reader.getRoot<VprOverrideDelayModel>();
+    ToNdMatrix<2, VprFloatEntry, float>(&delays, model.getDelays(), ToFloat);
+
+    base_delay_model_ = std::make_unique<DeltaDelayModel>(delays);
+
+    // Reading non-scalar capnproto fields is roughly equivilant to using
+    // a std::vector of the field type.  Actual type is capnp::List<X>::Reader.
+    auto overrides = model.getDelayOverrides();
+    std::vector<std::pair<t_override, float> > overrides_arr(overrides.size());
+    for (size_t i = 0; i < overrides.size(); ++i) {
+        const auto& elem = overrides[i];
+        overrides_arr[i].first.from_type = elem.getFromType();
+        overrides_arr[i].first.to_type = elem.getToType();
+        overrides_arr[i].first.from_class = elem.getFromClass();
+        overrides_arr[i].first.to_class = elem.getToClass();
+        overrides_arr[i].first.delta_x = elem.getDeltaX();
+        overrides_arr[i].first.delta_y = elem.getDeltaY();
+
+        overrides_arr[i].second = elem.getDelay();
+    }
+
+    delay_overrides_ = vtr::make_flat_map2(std::move(overrides_arr));
+}
+
+void OverrideDelayModel::write(const std::string& file) const {
+    ::capnp::MallocMessageBuilder builder;
+    auto model = builder.initRoot<VprOverrideDelayModel>();
+
+    auto delays = model.getDelays();
+    FromNdMatrix<2, VprFloatEntry, float>(&delays, base_delay_model_->delays(), FromFloat);
+
+    // Non-scalar capnproto fields should be first initialized with
+    // init<field  name>(count), and then accessed from the returned
+    // std::vector-like Builder object (specifically capnp::List<X>::Builder).
+    auto overrides = model.initDelayOverrides(delay_overrides_.size());
+    auto dst_iter = overrides.begin();
+    for (const auto& src : delay_overrides_) {
+        auto elem = *dst_iter++;
+        elem.setFromType(src.first.from_type);
+        elem.setToType(src.first.to_type);
+        elem.setFromClass(src.first.from_class);
+        elem.setToClass(src.first.to_class);
+        elem.setDeltaX(src.first.delta_x);
+        elem.setDeltaY(src.first.delta_y);
+
+        elem.setDelay(src.second);
+    }
+
+    writeMessageToFile(file, &builder);
+}
+
+#endif

--- a/vpr/src/place/place_delay_model.h
+++ b/vpr/src/place/place_delay_model.h
@@ -4,49 +4,88 @@
 #include "vtr_ndmatrix.h"
 #include "vtr_flat_map.h"
 #include "vpr_types.h"
-#include "router_lookahead_map.h"
+#include "router_delay_profiling.h"
 
 //Abstract interface to a placement delay model
 class PlaceDelayModel {
   public:
     virtual ~PlaceDelayModel() = default;
 
+    // Computes place delay model.
+    virtual void compute(
+        const RouterDelayProfiler& route_profiler,
+        const t_placer_opts& placer_opts,
+        const t_router_opts& router_opts,
+        int longest_length)
+        = 0;
+
     //Returns the delay estimate between the specified block pins
+    //
+    // Either compute or read methods must be invoked before invoking
+    // delay.
     virtual float delay(int from_x, int from_y, int from_pin, int to_x, int to_y, int to_pin) const = 0;
 
     //Dumps the delay model to an echo file
     virtual void dump_echo(std::string filename) const = 0;
+
+    // Write place delay model to specified file.
+    // May be unimplemented, in which case method should throw an exception.
+    virtual void write(const std::string& file) const = 0;
+
+    // Read place delay model from specified file.
+    // May be unimplemented, in which case method should throw an exception.
+    virtual void read(const std::string& file) = 0;
 };
 
 //A simple delay model based on the distance (delta) between block locations
 class DeltaDelayModel : public PlaceDelayModel {
   public:
-    DeltaDelayModel(vtr::Matrix<float> delta_delays, t_router_opts router_opts)
-        : delays_(std::move(delta_delays))
-        , router_opts_(router_opts) {}
+    DeltaDelayModel() {}
+    DeltaDelayModel(vtr::Matrix<float> delta_delays)
+        : delays_(std::move(delta_delays)) {}
 
+    void compute(
+        const RouterDelayProfiler& router,
+        const t_placer_opts& placer_opts,
+        const t_router_opts& router_opts,
+        int longest_length) override;
     float delay(int from_x, int from_y, int /*from_pin*/, int to_x, int to_y, int /*to_pin*/) const override;
     void dump_echo(std::string filepath) const override;
 
+    void read(const std::string& file) override;
+    void write(const std::string& file) const override;
+    const vtr::Matrix<float>& delays() const {
+        return delays_;
+    }
+
   private:
     vtr::Matrix<float> delays_;
-    t_router_opts router_opts_;
 };
 
 class OverrideDelayModel : public PlaceDelayModel {
   public:
-    OverrideDelayModel(std::unique_ptr<PlaceDelayModel> base_delay_model, t_router_opts router_opts)
-        : base_delay_model_(std::move(base_delay_model))
-        , router_opts_(router_opts) {}
-
+    void compute(
+        const RouterDelayProfiler& route_profiler,
+        const t_placer_opts& placer_opts,
+        const t_router_opts& router_opts,
+        int longest_length) override;
     float delay(int from_x, int from_y, int from_pin, int to_x, int to_y, int to_pin) const override;
     void dump_echo(std::string filepath) const override;
 
+    void read(const std::string& file) override;
+    void write(const std::string& file) const override;
+
   public: //Mutators
+    void set_base_delay_model(std::unique_ptr<DeltaDelayModel> base_delay_model);
+    const DeltaDelayModel* base_delay_model() const;
+    float get_delay_override(int from_type, int from_class, int to_type, int to_class, int delta_x, int delta_y) const;
     void set_delay_override(int from_type, int from_class, int to_type, int to_class, int delta_x, int delta_y, float delay);
 
   private:
-    std::unique_ptr<PlaceDelayModel> base_delay_model_;
+    std::unique_ptr<DeltaDelayModel> base_delay_model_;
+
+    void compute_override_delay_model(const RouterDelayProfiler& router,
+                                      const t_router_opts& router_opts);
 
     struct t_override {
         short from_type;
@@ -63,7 +102,6 @@ class OverrideDelayModel : public PlaceDelayModel {
     };
 
     vtr::flat_map2<t_override, float> delay_overrides_;
-    t_router_opts router_opts_;
 };
 
 #endif

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -69,23 +69,42 @@ struct t_profile_info {
 static t_chan_width setup_chan_width(const t_router_opts& router_opts,
                                      t_chan_width_dist chan_width_dist);
 
-static float route_connection_delay(int source_x_loc, int source_y_loc, int sink_x_loc, int sink_y_loc, const t_router_opts& router_opts, bool measure_directconnect);
+static float route_connection_delay(
+    const RouterDelayProfiler& route_profiler,
+    int source_x_loc,
+    int source_y_loc,
+    int sink_x_loc,
+    int sink_y_loc,
+    const t_router_opts& router_opts,
+    bool measure_directconnect);
 
-static void generic_compute_matrix(vtr::Matrix<std::vector<float>>& matrix,
-                                   int source_x,
-                                   int source_y,
-                                   int start_x,
-                                   int start_y,
-                                   int end_x,
-                                   int end_y,
-                                   const t_router_opts& router_opts,
-                                   bool measure_directconnect);
+static void generic_compute_matrix(
+    const RouterDelayProfiler& route_profiler,
+    vtr::Matrix<std::vector<float>>& matrix,
+    int source_x,
+    int source_y,
+    int start_x,
+    int start_y,
+    int end_x,
+    int end_y,
+    const t_router_opts& router_opts,
+    bool measure_directconnect);
 
-static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& palcer_opts, const t_router_opts& router_opts, bool measure_directconnect, size_t longest_length);
+static vtr::Matrix<float> compute_delta_delays(
+    const RouterDelayProfiler& route_profiler,
+    const t_placer_opts& palcer_opts,
+    const t_router_opts& router_opts,
+    bool measure_directconnect,
+    size_t longest_length);
 
 float delay_reduce(std::vector<float>& delays, e_reducer reducer);
 
-static vtr::Matrix<float> compute_delta_delay_model(const t_placer_opts& placer_opts, const t_router_opts& router_opts, bool measure_directconnect, int longest_length);
+static vtr::Matrix<float> compute_delta_delay_model(
+    const RouterDelayProfiler& route_profiler,
+    const t_placer_opts& placer_opts,
+    const t_router_opts& router_opts,
+    bool measure_directconnect,
+    int longest_length);
 
 static bool find_direct_connect_sample_locations(const t_direct_inf* direct,
                                                  t_type_ptr from_type,
@@ -96,8 +115,6 @@ static bool find_direct_connect_sample_locations(const t_direct_inf* direct,
                                                  int to_pin_class,
                                                  int* src_rr,
                                                  int* sink_rr);
-
-static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(const t_router_opts& router_opts, std::unique_ptr<PlaceDelayModel> base_model);
 
 static bool verify_delta_delays(const vtr::Matrix<float>& delta_delays);
 
@@ -126,30 +143,65 @@ std::unique_ptr<PlaceDelayModel> compute_place_delay_model(const t_placer_opts& 
     alloc_routing_structs(chan_width, router_opts, det_routing_arch, segment_inf,
                           directs, num_directs);
 
+    const RouterLookahead* router_lookahead = get_cached_router_lookahead(
+        router_opts.lookahead_type,
+        router_opts.write_router_lookahead,
+        router_opts.read_router_lookahead,
+        segment_inf);
+    RouterDelayProfiler route_profiler(router_lookahead);
+
     int longest_length = get_longest_segment_length(segment_inf);
 
     /*now setup and compute the actual arrays */
     std::unique_ptr<PlaceDelayModel> place_delay_model;
-    if (placer_opts.delay_model_type == PlaceDelayModelType::DELTA
-        || placer_opts.delay_model_type == PlaceDelayModelType::DELTA_OVERRIDE) {
-        bool measure_directconnect = (placer_opts.delay_model_type != PlaceDelayModelType::DELTA_OVERRIDE);
-
-        auto delta_delays = compute_delta_delay_model(placer_opts, router_opts, measure_directconnect, longest_length);
-        place_delay_model = std::make_unique<DeltaDelayModel>(std::move(delta_delays), router_opts);
-
+    if (placer_opts.delay_model_type == PlaceDelayModelType::DELTA) {
+        place_delay_model = std::make_unique<DeltaDelayModel>();
+    } else if (placer_opts.delay_model_type == PlaceDelayModelType::DELTA_OVERRIDE) {
+        place_delay_model = std::make_unique<OverrideDelayModel>();
     } else {
         VTR_ASSERT_MSG(false, "Invalid placer delay model");
     }
 
-    if (placer_opts.delay_model_type == PlaceDelayModelType::DELTA_OVERRIDE) {
-        //Override direct-connect delays
-        place_delay_model = compute_override_delay_model(router_opts, std::move(place_delay_model));
+    if (placer_opts.read_placement_delay_lookup.empty()) {
+        place_delay_model->compute(route_profiler, placer_opts, router_opts, longest_length);
+    } else {
+        place_delay_model->read(placer_opts.read_placement_delay_lookup);
+    }
+
+    if (!placer_opts.write_placement_delay_lookup.empty()) {
+        place_delay_model->write(placer_opts.write_placement_delay_lookup);
     }
 
     /*free all data structures that are no longer needed */
     free_routing_structs();
 
     return place_delay_model;
+}
+
+void DeltaDelayModel::compute(
+    const RouterDelayProfiler& route_profiler,
+    const t_placer_opts& placer_opts,
+    const t_router_opts& router_opts,
+    int longest_length) {
+    delays_ = compute_delta_delay_model(
+        route_profiler,
+        placer_opts, router_opts, /*measure_directconnect=*/true,
+        longest_length);
+}
+
+void OverrideDelayModel::compute(
+    const RouterDelayProfiler& route_profiler,
+    const t_placer_opts& placer_opts,
+    const t_router_opts& router_opts,
+    int longest_length) {
+    auto delays = compute_delta_delay_model(
+        route_profiler,
+        placer_opts, router_opts, /*measure_directconnect=*/false,
+        longest_length);
+
+    base_delay_model_ = std::make_unique<DeltaDelayModel>(delays);
+
+    compute_override_delay_model(route_profiler, router_opts);
 }
 
 /******* File Accessible Functions **********/
@@ -229,7 +281,14 @@ static t_chan_width setup_chan_width(const t_router_opts& router_opts,
     return init_chan(width_fac, chan_width_dist);
 }
 
-static float route_connection_delay(int source_x, int source_y, int sink_x, int sink_y, const t_router_opts& router_opts, bool measure_directconnect) {
+static float route_connection_delay(
+    const RouterDelayProfiler& route_profiler,
+    int source_x,
+    int source_y,
+    int sink_x,
+    int sink_y,
+    const t_router_opts& router_opts,
+    bool measure_directconnect) {
     //Routes between the source and sink locations and calculates the delay
 
     float net_delay_value = IMPOSSIBLE_DELTA; /*set to known value for debug purposes */
@@ -261,9 +320,12 @@ static float route_connection_delay(int source_x, int source_y, int sink_x, int 
                 continue;
             }
 
-            successfully_routed = calculate_delay(source_rr_node, sink_rr_node,
-                                                  router_opts,
-                                                  &net_delay_value);
+            {
+                successfully_routed = route_profiler.calculate_delay(
+                    source_rr_node, sink_rr_node,
+                    router_opts,
+                    &net_delay_value);
+            }
 
             if (successfully_routed) break;
         }
@@ -278,15 +340,17 @@ static float route_connection_delay(int source_x, int source_y, int sink_x, int 
     return (net_delay_value);
 }
 
-static void generic_compute_matrix(vtr::Matrix<std::vector<float>>& matrix,
-                                   int source_x,
-                                   int source_y,
-                                   int start_x,
-                                   int start_y,
-                                   int end_x,
-                                   int end_y,
-                                   const t_router_opts& router_opts,
-                                   bool measure_directconnect) {
+static void generic_compute_matrix(
+    const RouterDelayProfiler& route_profiler,
+    vtr::Matrix<std::vector<float>>& matrix,
+    int source_x,
+    int source_y,
+    int start_x,
+    int start_y,
+    int end_x,
+    int end_y,
+    const t_router_opts& router_opts,
+    bool measure_directconnect) {
     int delta_x, delta_y;
     int sink_x, sink_y;
 
@@ -318,7 +382,7 @@ static void generic_compute_matrix(vtr::Matrix<std::vector<float>>& matrix,
             } else {
                 //Valid start/end
 
-                float delay = route_connection_delay(source_x, source_y, sink_x, sink_y, router_opts, measure_directconnect);
+                float delay = route_connection_delay(route_profiler, source_x, source_y, sink_x, sink_y, router_opts, measure_directconnect);
 
 #ifdef VERBOSE
                 VTR_LOG("Computed delay: %12g delta: %d,%d (src: %d,%d sink: %d,%d)\n",
@@ -339,7 +403,12 @@ static void generic_compute_matrix(vtr::Matrix<std::vector<float>>& matrix,
     }
 }
 
-static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts, const t_router_opts& router_opts, bool measure_directconnect, size_t longest_length) {
+static vtr::Matrix<float> compute_delta_delays(
+    const RouterDelayProfiler& route_profiler,
+    const t_placer_opts& placer_opts,
+    const t_router_opts& router_opts,
+    bool measure_directconnect,
+    size_t longest_length) {
     //To avoid edge effects we place the source at least 'longest_length' away
     //from the device edge
     //and route from there for all possible delta values < dimension
@@ -405,7 +474,7 @@ static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts,
 #ifdef VERBOSE
     VTR_LOG("Computing from lower left edge (%d,%d):\n", x, y);
 #endif
-    generic_compute_matrix(sampled_delta_delays,
+    generic_compute_matrix(route_profiler, sampled_delta_delays,
                            x, y,
                            x, y,
                            grid.width() - 1, grid.height() - 1,
@@ -431,7 +500,7 @@ static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts,
 #ifdef VERBOSE
     VTR_LOG("Computing from left bottom edge (%d,%d):\n", x, y);
 #endif
-    generic_compute_matrix(sampled_delta_delays,
+    generic_compute_matrix(route_profiler, sampled_delta_delays,
                            x, y,
                            x, y,
                            grid.width() - 1, grid.height() - 1,
@@ -443,7 +512,7 @@ static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts,
 #ifdef VERBOSE
     VTR_LOG("Computing from low/low:\n");
 #endif
-    generic_compute_matrix(sampled_delta_delays,
+    generic_compute_matrix(route_profiler, sampled_delta_delays,
                            low_x, low_y,
                            low_x, low_y,
                            grid.width() - 1, grid.height() - 1,
@@ -455,7 +524,7 @@ static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts,
 #ifdef VERBOSE
     VTR_LOG("Computing from high/high:\n");
 #endif
-    generic_compute_matrix(sampled_delta_delays,
+    generic_compute_matrix(route_profiler, sampled_delta_delays,
                            high_x, high_y,
                            0, 0,
                            high_x, high_y,
@@ -467,7 +536,7 @@ static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts,
 #ifdef VERBOSE
     VTR_LOG("Computing from high/low:\n");
 #endif
-    generic_compute_matrix(sampled_delta_delays,
+    generic_compute_matrix(route_profiler, sampled_delta_delays,
                            high_x, low_y,
                            0, low_y,
                            high_x, grid.height() - 1,
@@ -479,7 +548,7 @@ static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts,
 #ifdef VERBOSE
     VTR_LOG("Computing from low/high:\n");
 #endif
-    generic_compute_matrix(sampled_delta_delays,
+    generic_compute_matrix(route_profiler, sampled_delta_delays,
                            low_x, high_y,
                            low_x, 0,
                            grid.width() - 1, high_y,
@@ -626,9 +695,15 @@ static void fill_impossible_coordinates(vtr::Matrix<float>& delta_delays) {
     }
 }
 
-static vtr::Matrix<float> compute_delta_delay_model(const t_placer_opts& placer_opts, const t_router_opts& router_opts, bool measure_directconnect, int longest_length) {
+static vtr::Matrix<float> compute_delta_delay_model(
+    const RouterDelayProfiler& route_profiler,
+    const t_placer_opts& placer_opts,
+    const t_router_opts& router_opts,
+    bool measure_directconnect,
+    int longest_length) {
     vtr::ScopedStartFinishTimer timer("Computing delta delays");
-    vtr::Matrix<float> delta_delays = compute_delta_delays(placer_opts, router_opts, measure_directconnect, longest_length);
+    vtr::Matrix<float> delta_delays = compute_delta_delays(route_profiler,
+                                                           placer_opts, router_opts, measure_directconnect, longest_length);
 
     fix_uninitialized_coordinates(delta_delays);
 
@@ -761,9 +836,9 @@ static bool verify_delta_delays(const vtr::Matrix<float>& delta_delays) {
     return true;
 }
 
-static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(const t_router_opts& router_opts, std::unique_ptr<PlaceDelayModel> base_model) {
-    auto delay_model = std::make_unique<OverrideDelayModel>(std::move(base_model), router_opts);
-
+void OverrideDelayModel::compute_override_delay_model(
+    const RouterDelayProfiler& route_profiler,
+    const t_router_opts& router_opts) {
     t_router_opts router_opts2 = router_opts;
     router_opts2.astar_fac = 0.;
 
@@ -824,10 +899,10 @@ static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(const t_
             VTR_ASSERT(sink_rr != OPEN);
 
             float direct_connect_delay = std::numeric_limits<float>::quiet_NaN();
-            bool found_routing_path = calculate_delay(src_rr, sink_rr, router_opts2, &direct_connect_delay);
+            bool found_routing_path = route_profiler.calculate_delay(src_rr, sink_rr, router_opts2, &direct_connect_delay);
 
             if (found_routing_path) {
-                delay_model->set_delay_override(from_type->index, from_pin_class, to_type->index, to_pin_class, direct->x_offset, direct->y_offset, direct_connect_delay);
+                set_delay_override(from_type->index, from_pin_class, to_type->index, to_pin_class, direct->x_offset, direct->y_offset, direct_connect_delay);
             } else {
                 ++missing_paths;
             }
@@ -839,8 +914,6 @@ static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(const t_
         VTR_LOGV_WARN(missing_instances > 0, "Found no delta delay for %d bits of inter-block direct connect '%s' (no instances of this direct found)\n", missing_instances, direct->name);
         VTR_LOGV_WARN(missing_paths > 0, "Found no delta delay for %d bits of inter-block direct connect '%s' (no routing path found)\n", missing_paths, direct->name);
     }
-
-    return delay_model;
 }
 
 bool directconnect_exists(int src_rr_node, int sink_rr_node) {

--- a/vpr/src/route/connection_box.cpp
+++ b/vpr/src/route/connection_box.cpp
@@ -1,0 +1,127 @@
+#include "connection_box.h"
+#include "vtr_assert.h"
+#include "globals.h"
+
+ConnectionBoxes::ConnectionBoxes()
+    : size_(std::make_pair(0, 0)) {
+}
+
+size_t ConnectionBoxes::num_connection_box_types() const {
+    return boxes_.size();
+}
+
+std::pair<size_t, size_t> ConnectionBoxes::connection_box_grid_size() const {
+    return size_;
+}
+
+const ConnectionBox* ConnectionBoxes::get_connection_box(ConnectionBoxId box) const {
+    if (bool(box)) {
+        return nullptr;
+    }
+
+    size_t index = size_t(box);
+    if (index >= boxes_.size()) {
+        return nullptr;
+    }
+
+    return &boxes_.at(index);
+}
+
+bool ConnectionBoxes::find_connection_box(int inode,
+                                          ConnectionBoxId* box_id,
+                                          std::pair<size_t, size_t>* box_location) const {
+    VTR_ASSERT(box_id != nullptr);
+    VTR_ASSERT(box_location != nullptr);
+
+    const auto& conn_box_loc = ipin_map_[inode];
+    if (conn_box_loc.box_id == ConnectionBoxId::INVALID()) {
+        return false;
+    }
+
+    *box_id = conn_box_loc.box_id;
+    *box_location = conn_box_loc.box_location;
+    return true;
+}
+
+// Clear IPIN map and set connection box grid size and box ids.
+void ConnectionBoxes::reset_boxes(std::pair<size_t, size_t> size,
+                                  const std::vector<ConnectionBox> boxes) {
+    clear();
+
+    size_ = size;
+    boxes_ = boxes;
+}
+
+void ConnectionBoxes::resize_nodes(size_t rr_node_size) {
+    ipin_map_.resize(rr_node_size);
+    canonical_loc_map_.resize(rr_node_size,
+                              std::make_pair(-1, -1));
+}
+
+void ConnectionBoxes::clear() {
+    ipin_map_.clear();
+    size_ = std::make_pair(0, 0);
+    boxes_.clear();
+    canonical_loc_map_.clear();
+    sink_to_ipin_.clear();
+}
+
+void ConnectionBoxes::add_connection_box(int inode, ConnectionBoxId box_id, std::pair<size_t, size_t> box_location) {
+    // Ensure that box location is in bounds
+    VTR_ASSERT(box_location.first < size_.first);
+    VTR_ASSERT(box_location.second < size_.second);
+
+    // Bounds check box_id
+    VTR_ASSERT(bool(box_id));
+    VTR_ASSERT(size_t(box_id) < boxes_.size());
+
+    // Make sure sink map will not be invalidated upon insertion.
+    VTR_ASSERT(sink_to_ipin_.size() == 0);
+
+    ipin_map_[inode] = ConnBoxLoc(box_location, box_id);
+}
+
+void ConnectionBoxes::add_canonical_loc(int inode, std::pair<size_t, size_t> loc) {
+    VTR_ASSERT(loc.first < size_.first);
+    VTR_ASSERT(loc.second < size_.second);
+    canonical_loc_map_[inode] = loc;
+}
+
+const std::pair<size_t, size_t>* ConnectionBoxes::find_canonical_loc(int inode) const {
+    const auto& canon_loc = canonical_loc_map_[inode];
+    if (canon_loc.first == size_t(-1)) {
+        return nullptr;
+    }
+
+    return &canon_loc;
+}
+
+void ConnectionBoxes::create_sink_back_ref() {
+    const auto& device_ctx = g_vpr_ctx.device();
+
+    sink_to_ipin_.resize(device_ctx.rr_nodes.size(), {{0, 0, 0, 0}, 0});
+
+    for (size_t i = 0; i < device_ctx.rr_nodes.size(); ++i) {
+        const auto& ipin_node = device_ctx.rr_nodes[i];
+        if (ipin_node.type() != IPIN) {
+            continue;
+        }
+
+        if (ipin_map_[i].box_id == ConnectionBoxId::INVALID()) {
+            continue;
+        }
+
+        for (auto edge : ipin_node.edges()) {
+            int sink_inode = ipin_node.edge_sink_node(edge);
+            VTR_ASSERT(device_ctx.rr_nodes[sink_inode].type() == SINK);
+            VTR_ASSERT(sink_to_ipin_[sink_inode].ipin_count < 4);
+            auto& sink_to_ipin = sink_to_ipin_[sink_inode];
+            sink_to_ipin.ipin_nodes[sink_to_ipin.ipin_count++] = i;
+        }
+    }
+}
+
+const SinkToIpin& ConnectionBoxes::find_sink_connection_boxes(
+    int inode) const {
+    return sink_to_ipin_[inode];
+}

--- a/vpr/src/route/connection_box.h
+++ b/vpr/src/route/connection_box.h
@@ -1,0 +1,76 @@
+#ifndef CONNECTION_BOX_H
+#define CONNECTION_BOX_H
+// Some routing graphs have connectivity driven by types of connection boxes.
+// This class relates IPIN rr nodes with connection box type and locations, used
+// for connection box driven map lookahead.
+
+#include <tuple>
+#include "vtr_strong_id.h"
+#include "vtr_flat_map.h"
+#include "vtr_range.h"
+#include <map>
+
+struct connection_box_tag {};
+typedef vtr::StrongId<connection_box_tag> ConnectionBoxId;
+
+struct ConnectionBox {
+    std::string name;
+};
+
+struct ConnBoxLoc {
+    ConnBoxLoc()
+        : box_location(std::make_pair(-1, -1)) {}
+    ConnBoxLoc(
+        const std::pair<size_t, size_t>& a_box_location,
+        ConnectionBoxId a_box_id)
+        : box_location(a_box_location)
+        , box_id(a_box_id) {}
+
+    std::pair<size_t, size_t> box_location;
+    ConnectionBoxId box_id;
+};
+
+struct SinkToIpin {
+    int ipin_nodes[4];
+    int ipin_count;
+};
+
+class ConnectionBoxes {
+  public:
+    ConnectionBoxes();
+
+    size_t num_connection_box_types() const;
+    std::pair<size_t, size_t> connection_box_grid_size() const;
+    const ConnectionBox* get_connection_box(ConnectionBoxId box) const;
+
+    bool find_connection_box(int inode,
+                             ConnectionBoxId* box_id,
+                             std::pair<size_t, size_t>* box_location) const;
+    const std::pair<size_t, size_t>* find_canonical_loc(int inode) const;
+
+    // Clear IPIN map and set connection box grid size and box ids.
+    void clear();
+    void reset_boxes(std::pair<size_t, size_t> size,
+                     const std::vector<ConnectionBox> boxes);
+    void resize_nodes(size_t rr_node_size);
+
+    void add_connection_box(int inode, ConnectionBoxId box_id, std::pair<size_t, size_t> box_location);
+    void add_canonical_loc(int inode, std::pair<size_t, size_t> loc);
+
+    // Create map from SINK's back to IPIN's
+    //
+    // This must be called after all connection boxes have been added.
+    void create_sink_back_ref();
+    const SinkToIpin& find_sink_connection_boxes(
+        int inode) const;
+
+  private:
+    std::pair<size_t, size_t> size_;
+    std::vector<ConnectionBox> boxes_;
+    std::vector<ConnBoxLoc> ipin_map_;
+    std::vector<SinkToIpin> sink_to_ipin_;
+    std::vector<std::pair<size_t, size_t>>
+        canonical_loc_map_;
+};
+
+#endif

--- a/vpr/src/route/connection_box_lookahead_map.cpp
+++ b/vpr/src/route/connection_box_lookahead_map.cpp
@@ -1,0 +1,578 @@
+#include "connection_box_lookahead_map.h"
+
+#include <vector>
+#include <queue>
+
+#include "connection_box.h"
+#include "rr_node.h"
+#include "router_lookahead_map_utils.h"
+#include "globals.h"
+#include "vtr_math.h"
+#include "vtr_time.h"
+#include "echo_files.h"
+
+#include "route_timing.h"
+
+#include "capnp/serialize.h"
+#include "connection_map.capnp.h"
+#include "ndmatrix_serdes.h"
+#include "mmap_file.h"
+#include "serdes_utils.h"
+
+/* we're profiling routing cost over many tracks for each wire type, so we'll
+ * have many cost entries at each |dx|,|dy| offset. There are many ways to
+ * "boil down" the many costs at each offset to a single entry for a given
+ * (wire type, chan_type) combination we can take the smallest cost, the
+ * average, median, etc. This define selects the method we use.
+ *
+ * See e_representative_entry_method */
+#define REPRESENTATIVE_ENTRY_METHOD SMALLEST
+
+#define REF_X 25
+#define REF_Y 23
+
+static int signum(int x) {
+    if (x > 0) return 1;
+    if (x < 0)
+        return -1;
+    else
+        return 0;
+}
+
+typedef std::vector<std::pair<std::pair<int, int>, Cost_Entry>> t_routing_cost_map;
+static void run_dijkstra(int start_node_ind,
+                         t_routing_cost_map* cost_map);
+
+class CostMap {
+  public:
+    void set_segment_count(size_t seg_count) {
+        cost_map_.clear();
+        offset_.clear();
+        cost_map_.resize(seg_count);
+        offset_.resize(seg_count);
+
+        const auto& device_ctx = g_vpr_ctx.device();
+        segment_map_.resize(device_ctx.rr_nodes.size());
+        for (size_t i = 0; i < segment_map_.size(); ++i) {
+            auto& from_node = device_ctx.rr_nodes[i];
+
+            int from_cost_index = from_node.cost_index();
+            int from_seg_index = device_ctx.rr_indexed_data[from_cost_index].seg_index;
+
+            segment_map_[i] = from_seg_index;
+        }
+    }
+
+    int node_to_segment(int from_node_ind) {
+        return segment_map_[from_node_ind];
+    }
+
+    Cost_Entry find_cost(int from_seg_index, int delta_x, int delta_y) const {
+        VTR_ASSERT(from_seg_index >= 0 && from_seg_index < (ssize_t)offset_.size());
+        int dx = delta_x - offset_[from_seg_index].first;
+        int dy = delta_y - offset_[from_seg_index].second;
+        const auto& cost_map = cost_map_[from_seg_index];
+
+        if (dx < 0) {
+            dx = 0;
+        }
+        if (dy < 0) {
+            dy = 0;
+        }
+
+        if (dx >= (ssize_t)cost_map.dim_size(0)) {
+            dx = cost_map.dim_size(0) - 1;
+        }
+        if (dy >= (ssize_t)cost_map.dim_size(1)) {
+            dy = cost_map.dim_size(1) - 1;
+        }
+
+        return cost_map_[from_seg_index][dx][dy];
+    }
+
+    void set_cost_map(int from_seg_index,
+                      const t_routing_cost_map& cost_map,
+                      e_representative_entry_method method) {
+        VTR_ASSERT(from_seg_index >= 0 && from_seg_index < (ssize_t)offset_.size());
+
+        // Find coordinate offset for this segment.
+        int min_dx = 0;
+        int min_dy = 0;
+        int max_dx = 0;
+        int max_dy = 0;
+        for (const auto& entry : cost_map) {
+            min_dx = std::min(entry.first.first, min_dx);
+            min_dy = std::min(entry.first.second, min_dy);
+
+            max_dx = std::max(entry.first.first, max_dx);
+            max_dy = std::max(entry.first.second, max_dy);
+        }
+
+        offset_[from_seg_index].first = min_dx;
+        offset_[from_seg_index].second = min_dy;
+        size_t dim_x = max_dx - min_dx + 1;
+        size_t dim_y = max_dy - min_dy + 1;
+
+        vtr::NdMatrix<Expansion_Cost_Entry, 2> expansion_cost_map(
+            {dim_x, dim_y});
+
+        for (const auto& entry : cost_map) {
+            int x = entry.first.first - min_dx;
+            int y = entry.first.second - min_dy;
+            expansion_cost_map[x][y].add_cost_entry(
+                method, entry.second.delay,
+                entry.second.congestion);
+        }
+
+        cost_map_[from_seg_index] = vtr::NdMatrix<Cost_Entry, 2>(
+            {dim_x, dim_y});
+
+        /* set the lookahead cost map entries with a representative cost
+         * entry from routing_cost_map */
+        for (unsigned ix = 0; ix < expansion_cost_map.dim_size(0); ix++) {
+            for (unsigned iy = 0; iy < expansion_cost_map.dim_size(1); iy++) {
+                cost_map_[from_seg_index][ix][iy] = expansion_cost_map[ix][iy].get_representative_cost_entry(method);
+            }
+        }
+
+        /* find missing cost entries and fill them in by copying a nearby cost entry */
+        for (unsigned ix = 0; ix < expansion_cost_map.dim_size(0); ix++) {
+            for (unsigned iy = 0; iy < expansion_cost_map.dim_size(1); iy++) {
+                Cost_Entry cost_entry = cost_map_[from_seg_index][ix][iy];
+
+                if (!cost_entry.valid()) {
+                    Cost_Entry copied_entry = get_nearby_cost_entry(
+                        from_seg_index,
+                        offset_[from_seg_index].first + ix,
+                        offset_[from_seg_index].second + iy);
+                    cost_map_[from_seg_index][ix][iy] = copied_entry;
+                }
+            }
+        }
+    }
+
+    Cost_Entry get_nearby_cost_entry(int segment_index, int x, int y) {
+        /* compute the slope from x,y to 0,0 and then move towards 0,0 by one
+         * unit to get the coordinates of the cost entry to be copied */
+
+        float slope;
+        int copy_x, copy_y;
+        if (x == 0 || y == 0) {
+            slope = std::numeric_limits<float>::infinity();
+            copy_x = x - signum(x);
+            copy_y = y - signum(y);
+        } else {
+            slope = (float)y / (float)x;
+            if (slope >= 1.0) {
+                copy_y = y - signum(y);
+                copy_x = vtr::nint((float)y / slope);
+            } else {
+                copy_x = x - signum(x);
+                copy_y = vtr::nint((float)x * slope);
+            }
+        }
+
+        Cost_Entry copy_entry = find_cost(segment_index, copy_x, copy_y);
+
+        /* if the entry to be copied is also empty, recurse */
+        if (copy_entry.valid()) {
+            return copy_entry;
+        } else if (copy_x == 0 && copy_y == 0) {
+            return Cost_Entry();
+        }
+
+        return get_nearby_cost_entry(segment_index, copy_x, copy_y);
+    }
+
+    void print_cost_map(const std::vector<t_segment_inf>& segment_inf,
+                        const char* fname) {
+        FILE* fp = vtr::fopen(fname, "w");
+        for (size_t iseg = 0; iseg < cost_map_.size(); iseg++) {
+            fprintf(fp, "Seg %s(%zu) (%d, %d)\n", segment_inf.at(iseg).name.c_str(),
+                    iseg,
+                    offset_[iseg].first,
+                    offset_[iseg].second);
+            for (size_t iy = 0; iy < cost_map_[iseg].dim_size(1); iy++) {
+                for (size_t ix = 0; ix < cost_map_[iseg].dim_size(0); ix++) {
+                    fprintf(fp, "%.4g,\t",
+                            cost_map_[iseg][ix][iy].delay);
+                }
+                fprintf(fp, "\n");
+            }
+            fprintf(fp, "\n\n");
+        }
+
+        fclose(fp);
+    }
+
+    void read(const std::string& file);
+    void write(const std::string& file) const;
+
+  private:
+    std::vector<vtr::NdMatrix<Cost_Entry, 2>> cost_map_;
+    std::vector<std::pair<int, int>> offset_;
+    std::vector<int> segment_map_;
+};
+
+static CostMap g_cost_map;
+
+class StartNode {
+  public:
+    StartNode(int start_x, int start_y, t_rr_type rr_type, int seg_index)
+        : start_x_(start_x)
+        , start_y_(start_y)
+        , rr_type_(rr_type)
+        , seg_index_(seg_index)
+        , index_(0) {}
+    int get_next_node() {
+        const auto& device_ctx = g_vpr_ctx.device();
+        const std::vector<int>& channel_node_list = device_ctx.rr_node_indices[rr_type_][start_x_][start_y_][0];
+
+        for (; index_ < channel_node_list.size(); index_++) {
+            int node_ind = channel_node_list[index_];
+
+            if (node_ind == OPEN || device_ctx.rr_nodes[node_ind].capacity() == 0) {
+                continue;
+            }
+
+            const std::pair<size_t, size_t>* loc = device_ctx.connection_boxes.find_canonical_loc(node_ind);
+            if (loc == nullptr) {
+                continue;
+            }
+
+            int node_cost_ind = device_ctx.rr_nodes[node_ind].cost_index();
+            int node_seg_ind = device_ctx.rr_indexed_data[node_cost_ind].seg_index;
+            if (node_seg_ind == seg_index_) {
+                index_ += 1;
+                return node_ind;
+            }
+        }
+
+        return UNDEFINED;
+    }
+
+  private:
+    int start_x_;
+    int start_y_;
+    t_rr_type rr_type_;
+    int seg_index_;
+    size_t index_;
+};
+
+// Minimum size of search for channels to profile.  kMinProfile results
+// in searching x = [0, kMinProfile], and y = [0, kMinProfile[.
+//
+// Making this value larger will increase the sample size, but also the runtime
+// to produce the lookahead.
+static constexpr int kMinProfile = 1;
+
+// Maximum size of search for channels to profile.  Once search is outside of
+// kMinProfile distance, lookahead will stop searching once:
+//  - At least one channel has been profiled
+//  - kMaxProfile is exceeded.
+static constexpr int kMaxProfile = 7;
+
+static void compute_connection_box_lookahead(
+    const std::vector<t_segment_inf>& segment_inf) {
+    size_t num_segments = segment_inf.size();
+    vtr::ScopedStartFinishTimer timer("Computing connection box lookahead map");
+
+    /* free previous delay map and allocate new one */
+    g_cost_map.set_segment_count(segment_inf.size());
+
+    /* run Dijkstra's algorithm for each segment type & channel type combination */
+    for (int iseg = 0; iseg < (ssize_t)num_segments; iseg++) {
+        VTR_LOG("Creating cost map for %s(%d)\n",
+                segment_inf[iseg].name.c_str(), iseg);
+        /* allocate the cost map for this iseg/chan_type */
+        t_routing_cost_map cost_map;
+
+        int count = 0;
+
+        int dx = 0;
+        int dy = 0;
+        //int start_x = vtr::nint(device_ctx.grid.width()/2);
+        //int start_y = vtr::nint(device_ctx.grid.height()/2);
+        int start_x = REF_X;
+        int start_y = REF_Y;
+        while ((count == 0 && dx < kMaxProfile) || dy <= kMinProfile) {
+            for (e_rr_type chan_type : {CHANX, CHANY}) {
+                StartNode start_node(start_x + dx, start_y + dy, chan_type, iseg);
+
+                for (int start_node_ind = start_node.get_next_node();
+                     start_node_ind != UNDEFINED;
+                     start_node_ind = start_node.get_next_node()) {
+                    count += 1;
+
+                    /* run Dijkstra's algorithm */
+                    run_dijkstra(start_node_ind, &cost_map);
+                }
+            }
+
+            if (dy < dx) {
+                dy += 1;
+            } else {
+                dx += 1;
+            }
+        }
+
+        if (count == 0) {
+            VTR_LOG_WARN("Segment %s(%d) found no start_node_ind\n",
+                         segment_inf[iseg].name.c_str(), iseg);
+        }
+
+        /* boil down the cost list in routing_cost_map at each coordinate to a
+         * representative cost entry and store it in the lookahead cost map */
+        g_cost_map.set_cost_map(iseg, cost_map,
+                                REPRESENTATIVE_ENTRY_METHOD);
+    }
+
+    if (getEchoEnabled() && isEchoFileEnabled(E_ECHO_LOOKAHEAD_MAP)) {
+        g_cost_map.print_cost_map(segment_inf, getEchoFileName(E_ECHO_LOOKAHEAD_MAP));
+    }
+}
+
+static float get_connection_box_lookahead_map_cost(int from_node_ind,
+                                                   int to_node_ind,
+                                                   float criticality_fac) {
+    if (from_node_ind == to_node_ind) {
+        return 0.f;
+    }
+
+    auto& device_ctx = g_vpr_ctx.device();
+
+    std::pair<size_t, size_t> from_location;
+    std::pair<size_t, size_t> to_location;
+    auto to_node_type = device_ctx.rr_nodes[to_node_ind].type();
+
+    if (to_node_type == SINK) {
+        const auto& sink_to_ipin = device_ctx.connection_boxes.find_sink_connection_boxes(to_node_ind);
+        if (sink_to_ipin.ipin_count > 1) {
+            float cost = std::numeric_limits<float>::infinity();
+            // Find cheapest cost from from_node_ind to IPINs for this SINK.
+            for (int i = 0; i < sink_to_ipin.ipin_count; ++i) {
+                cost = std::min(cost,
+                                get_connection_box_lookahead_map_cost(
+                                    from_node_ind,
+                                    sink_to_ipin.ipin_nodes[i], criticality_fac));
+            }
+
+            return cost;
+        } else if (sink_to_ipin.ipin_count == 1) {
+            to_node_ind = sink_to_ipin.ipin_nodes[0];
+            if (from_node_ind == to_node_ind) {
+                return 0.f;
+            }
+        } else {
+            return std::numeric_limits<float>::infinity();
+        }
+    }
+
+    if (device_ctx.rr_nodes[to_node_ind].type() == IPIN) {
+        ConnectionBoxId box_id;
+        std::pair<size_t, size_t> box_location;
+        bool found = device_ctx.connection_boxes.find_connection_box(
+            to_node_ind, &box_id, &box_location);
+        if (!found) {
+            VPR_THROW(VPR_ERROR_ROUTE, "No connection box for IPIN %d", to_node_ind);
+        }
+
+        to_location = box_location;
+    } else {
+        const std::pair<size_t, size_t>* to_canonical_loc = device_ctx.connection_boxes.find_canonical_loc(to_node_ind);
+        if (!to_canonical_loc) {
+            VPR_THROW(VPR_ERROR_ROUTE, "No canonical loc for %d", to_node_ind);
+        }
+
+        to_location = *to_canonical_loc;
+    }
+
+    const std::pair<size_t, size_t>* from_canonical_loc = device_ctx.connection_boxes.find_canonical_loc(from_node_ind);
+    if (from_canonical_loc == nullptr) {
+        VPR_THROW(VPR_ERROR_ROUTE, "No canonical loc for %d (to %d)",
+                  from_node_ind, to_node_ind);
+    }
+
+    ssize_t dx = ssize_t(from_canonical_loc->first) - ssize_t(to_location.first);
+    ssize_t dy = ssize_t(from_canonical_loc->second) - ssize_t(to_location.second);
+
+    int from_seg_index = g_cost_map.node_to_segment(from_node_ind);
+    Cost_Entry cost_entry = g_cost_map.find_cost(from_seg_index, dx, dy);
+    float expected_delay = cost_entry.delay;
+    float expected_congestion = cost_entry.congestion;
+
+    float expected_cost = criticality_fac * expected_delay + (1.0 - criticality_fac) * expected_congestion;
+    return expected_cost;
+}
+
+/* runs Dijkstra's algorithm from specified node until all nodes have been
+ * visited. Each time a pin is visited, the delay/congestion information
+ * to that pin is stored to an entry in the routing_cost_map */
+static void run_dijkstra(int start_node_ind,
+                         t_routing_cost_map* routing_cost_map) {
+    auto& device_ctx = g_vpr_ctx.device();
+
+    /* a list of boolean flags (one for each rr node) to figure out if a
+     * certain node has already been expanded */
+    std::vector<bool> node_expanded(device_ctx.rr_nodes.size(), false);
+    /* for each node keep a list of the cost with which that node has been
+     * visited (used to determine whether to push a candidate node onto the
+     * expansion queue */
+    std::vector<float> node_visited_costs(device_ctx.rr_nodes.size(), -1.0);
+    /* a priority queue for expansion */
+    std::priority_queue<util::PQ_Entry> pq;
+
+    /* first entry has no upstream delay or congestion */
+    util::PQ_Entry first_entry(start_node_ind, UNDEFINED, 0, 0, 0, true);
+
+    pq.push(first_entry);
+
+    const std::pair<size_t, size_t>* from_canonical_loc = device_ctx.connection_boxes.find_canonical_loc(start_node_ind);
+    if (from_canonical_loc == nullptr) {
+        VPR_THROW(VPR_ERROR_ROUTE, "No canonical location of node %d",
+                  start_node_ind);
+    }
+
+    /* now do routing */
+    while (!pq.empty()) {
+        util::PQ_Entry current = pq.top();
+        pq.pop();
+
+        int node_ind = current.rr_node_ind;
+
+        /* check that we haven't already expanded from this node */
+        if (node_expanded[node_ind]) {
+            continue;
+        }
+
+        /* if this node is an ipin record its congestion/delay in the routing_cost_map */
+        if (device_ctx.rr_nodes[node_ind].type() == IPIN) {
+            ConnectionBoxId box_id;
+            std::pair<size_t, size_t> box_location;
+            bool found = device_ctx.connection_boxes.find_connection_box(
+                node_ind, &box_id, &box_location);
+            if (!found) {
+                VPR_THROW(VPR_ERROR_ROUTE, "No connection box for IPIN %d", node_ind);
+            }
+
+            int delta_x = ssize_t(from_canonical_loc->first) - ssize_t(box_location.first);
+            int delta_y = ssize_t(from_canonical_loc->second) - ssize_t(box_location.second);
+
+            routing_cost_map->push_back(std::make_pair(
+                std::make_pair(delta_x, delta_y),
+                Cost_Entry(
+                    current.delay,
+                    current.congestion_upstream)));
+        }
+
+        expand_dijkstra_neighbours(current, node_visited_costs, node_expanded, pq);
+        node_expanded[node_ind] = true;
+    }
+}
+
+void ConnectionBoxMapLookahead::compute(const std::vector<t_segment_inf>& segment_inf) {
+    compute_connection_box_lookahead(segment_inf);
+}
+
+float ConnectionBoxMapLookahead::get_expected_cost(
+    int current_node,
+    int target_node,
+    const t_conn_cost_params& params,
+    float /*R_upstream*/) const {
+    auto& device_ctx = g_vpr_ctx.device();
+
+    t_rr_type rr_type = device_ctx.rr_nodes[current_node].type();
+
+    if (rr_type == CHANX || rr_type == CHANY) {
+        return get_connection_box_lookahead_map_cost(
+            current_node, target_node, params.criticality);
+    } else if (rr_type == IPIN) { /* Change if you're allowing route-throughs */
+        return (device_ctx.rr_indexed_data[SINK_COST_INDEX].base_cost);
+    } else { /* Change this if you want to investigate route-throughs */
+        return (0.);
+    }
+}
+
+void ConnectionBoxMapLookahead::read(const std::string& file) {
+    g_cost_map.read(file);
+}
+void ConnectionBoxMapLookahead::write(const std::string& file) const {
+    g_cost_map.write(file);
+}
+
+static void ToCostEntry(Cost_Entry* out, const VprCostEntry::Reader& in) {
+    out->delay = in.getDelay();
+    out->congestion = in.getCongestion();
+}
+
+static void FromCostEntry(VprCostEntry::Builder* out, const Cost_Entry& in) {
+    out->setDelay(in.delay);
+    out->setCongestion(in.congestion);
+}
+
+void CostMap::read(const std::string& file) {
+    MmapFile f(file);
+    ::capnp::FlatArrayMessageReader reader(f.getData());
+
+    auto cost_map = reader.getRoot<VprCostMap>();
+
+    {
+        const auto& segment_map = cost_map.getSegmentMap();
+        segment_map_.resize(segment_map.size());
+        auto dst_iter = segment_map_.begin();
+        for (const auto& src : segment_map) {
+            *dst_iter++ = src;
+        }
+    }
+
+    {
+        const auto& offset = cost_map.getOffset();
+        offset_.resize(offset.size());
+        auto dst_iter = offset_.begin();
+        for (const auto& src : offset) {
+            *dst_iter++ = std::make_pair(src.getX(), src.getY());
+        }
+    }
+
+    {
+        const auto& cost_maps = cost_map.getCostMap();
+        cost_map_.resize(cost_maps.size());
+        auto dst_iter = cost_map_.begin();
+        for (const auto& src : cost_maps) {
+            ToNdMatrix<2, VprCostEntry, Cost_Entry>(&(*dst_iter++), src, ToCostEntry);
+        }
+    }
+}
+
+void CostMap::write(const std::string& file) const {
+    ::capnp::MallocMessageBuilder builder;
+
+    auto cost_map = builder.initRoot<VprCostMap>();
+
+    {
+        auto segment_map = cost_map.initSegmentMap(segment_map_.size());
+        for (size_t i = 0; i < segment_map_.size(); ++i) {
+            segment_map.set(i, segment_map_[i]);
+        }
+    }
+
+    {
+        auto offset = cost_map.initOffset(offset_.size());
+        for (size_t i = 0; i < offset_.size(); ++i) {
+            auto elem = offset[i];
+            elem.setX(offset_[i].first);
+            elem.setY(offset_[i].second);
+        }
+    }
+
+    {
+        auto cost_maps = cost_map.initCostMap(cost_map_.size());
+        for (size_t i = 0; i < cost_map_.size(); ++i) {
+            Matrix<VprCostEntry>::Builder elem = cost_maps[i];
+            FromNdMatrix<2, VprCostEntry, Cost_Entry>(
+                &elem, cost_map_[i], FromCostEntry);
+        }
+    }
+
+    writeMessageToFile(file, &builder);
+}

--- a/vpr/src/route/connection_box_lookahead_map.h
+++ b/vpr/src/route/connection_box_lookahead_map.h
@@ -1,0 +1,17 @@
+#ifndef CONNECTION_BOX_LOOKAHEAD_H_
+#define CONNECTION_BOX_LOOKAHEAD_H_
+
+#include <vector>
+#include "physical_types.h"
+#include "router_lookahead.h"
+
+class ConnectionBoxMapLookahead : public RouterLookahead {
+  public:
+    float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    void compute(const std::vector<t_segment_inf>& segment_inf) override;
+
+    void read(const std::string& file) override;
+    void write(const std::string& file) const override;
+};
+
+#endif

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -237,7 +237,6 @@ void try_graph(int width_fac, const t_router_opts& router_opts, t_det_routing_ar
                     router_opts.trim_empty_channels,
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
-                    router_opts.lookahead_type,
                     directs, num_directs,
                     &warning_count);
 }
@@ -289,7 +288,6 @@ bool try_route(int width_fac,
                     router_opts.trim_empty_channels,
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
-                    router_opts.lookahead_type,
                     directs, num_directs,
                     &warning_count);
 
@@ -318,6 +316,7 @@ bool try_route(int width_fac,
 
         success = try_timing_driven_route(router_opts,
                                           analysis_opts,
+                                          segment_inf,
                                           net_delay,
                                           netlist_pin_lookup,
                                           timing_info,

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -300,6 +300,7 @@ static void generate_route_timing_reports(const t_router_opts& router_opts,
 /************************ Subroutine definitions *****************************/
 bool try_timing_driven_route(const t_router_opts& router_opts,
                              const t_analysis_opts& analysis_opts,
+                             const std::vector<t_segment_inf>& segment_inf,
                              vtr::vector<ClusterNetId, float*>& net_delay,
                              const ClusteredPinAtomPinsLookup& netlist_pin_lookup,
                              std::shared_ptr<SetupHoldTimingInfo> timing_info,
@@ -354,7 +355,11 @@ bool try_timing_driven_route(const t_router_opts& router_opts,
 
     route_budgets budgeting_inf;
 
-    auto router_lookahead = make_router_lookahead(router_opts.lookahead_type);
+    const auto* router_lookahead = get_cached_router_lookahead(
+        router_opts.lookahead_type,
+        router_opts.write_router_lookahead,
+        router_opts.read_router_lookahead,
+        segment_inf);
 
     /*
      * Routing parameters
@@ -1365,7 +1370,9 @@ std::vector<t_heap> timing_driven_find_all_shortest_paths_from_route_tree(t_rt_n
                                                                           RouterStats& router_stats) {
     //Add the route tree to the heap with no specific target node
     int target_node = OPEN;
-    auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP);
+    auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP,
+                                                  /*write_lookahead=*/"", /*read_lookahead=*/"",
+                                                  /*segment_inf=*/{});
     add_route_tree_to_heap(rt_root, target_node, cost_params, *router_lookahead, router_stats);
     heap_::build_heap(); // via sifting down everything
 
@@ -1385,7 +1392,9 @@ static std::vector<t_heap> timing_driven_find_all_shortest_paths_from_heap(const
                                                                            t_bb bounding_box,
                                                                            std::vector<int>& modified_rr_node_inf,
                                                                            RouterStats& router_stats) {
-    auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP);
+    auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP,
+                                                  /*write_lookahead=*/"", /*read_lookahead=*/"",
+                                                  /*segment_inf=*/{});
 
     auto& device_ctx = g_vpr_ctx.device();
     std::vector<t_heap> cheapest_paths(device_ctx.rr_nodes.size());

--- a/vpr/src/route/route_timing.h
+++ b/vpr/src/route/route_timing.h
@@ -15,6 +15,7 @@ int get_max_pins_per_net();
 
 bool try_timing_driven_route(const t_router_opts& router_opts,
                              const t_analysis_opts& analysis_opts,
+                             const std::vector<t_segment_inf>& segment_inf,
                              vtr::vector<ClusterNetId, float*>& net_delay,
                              const ClusteredPinAtomPinsLookup& netlist_pin_lookup,
                              std::shared_ptr<SetupHoldTimingInfo> timing_info,

--- a/vpr/src/route/router_delay_profiling.cpp
+++ b/vpr/src/route/router_delay_profiling.cpp
@@ -9,7 +9,11 @@
 
 static t_rt_node* setup_routing_resources_no_net(int source_node);
 
-bool calculate_delay(int source_node, int sink_node, const t_router_opts& router_opts, float* net_delay) {
+RouterDelayProfiler::RouterDelayProfiler(
+    const RouterLookahead* lookahead)
+    : router_lookahead_(lookahead) {}
+
+bool RouterDelayProfiler::calculate_delay(int source_node, int sink_node, const t_router_opts& router_opts, float* net_delay) const {
     /* Returns true as long as found some way to hook up this net, even if that *
      * way resulted in overuse of resources (congestion).  If there is no way   *
      * to route this net, even ignoring congestion, it returns false.  In this  *
@@ -41,8 +45,9 @@ bool calculate_delay(int source_node, int sink_node, const t_router_opts& router
 
     std::vector<int> modified_rr_node_inf;
     RouterStats router_stats;
-    auto router_lookahead = make_router_lookahead(router_opts.lookahead_type);
-    t_heap* cheapest = timing_driven_route_connection_from_route_tree(rt_root, sink_node, cost_params, bounding_box, *router_lookahead, modified_rr_node_inf, router_stats);
+    t_heap* cheapest = timing_driven_route_connection_from_route_tree(rt_root,
+                                                                      sink_node, cost_params, bounding_box, *router_lookahead_,
+                                                                      modified_rr_node_inf, router_stats);
 
     bool found_path = (cheapest != nullptr);
     if (found_path) {
@@ -125,7 +130,7 @@ std::vector<float> calculate_all_path_delays_from_rr_node(int src_rr_node, const
     for (int sink_rr_node = 0; sink_rr_node < (int) device_ctx.rr_nodes.size(); ++sink_rr_node) {
 
         float astar_delay = std::numeric_limits<float>::quiet_NaN();
-        if (sink_rr_node == src_rr_node) { 
+        if (sink_rr_node == src_rr_node) {
             astar_delay = 0.;
         } else {
             calculate_delay(src_rr_node, sink_rr_node, router_opts, &astar_delay);
@@ -191,7 +196,6 @@ void alloc_routing_structs(t_chan_width chan_width,
                     router_opts.trim_empty_channels,
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
-                    router_opts.lookahead_type,
                     directs, num_directs,
                     &warnings);
 

--- a/vpr/src/route/router_delay_profiling.h
+++ b/vpr/src/route/router_delay_profiling.h
@@ -1,8 +1,19 @@
+#ifndef ROUTER_DELAY_PROFILING_H_
+#define ROUTER_DELAY_PROFILING_H_
+
 #include "vpr_types.h"
+#include "router_lookahead.h"
 
 #include <vector>
 
-bool calculate_delay(int source_node, int sink_node, const t_router_opts& router_opts, float* net_delay);
+class RouterDelayProfiler {
+  public:
+    RouterDelayProfiler(const RouterLookahead* lookahead);
+    bool calculate_delay(int source_node, int sink_node, const t_router_opts& router_opts, float* net_delay) const;
+
+  private:
+    const RouterLookahead* router_lookahead_;
+};
 
 std::vector<float> calculate_all_path_delays_from_rr_node(int src_rr_node, const t_router_opts& router_opts);
 
@@ -14,3 +25,5 @@ void alloc_routing_structs(t_chan_width chan_width,
                            const int num_directs);
 
 void free_routing_structs();
+
+#endif /* ROUTER_DELAY_PROFILING_H_ */

--- a/vpr/src/route/router_lookahead.cpp
+++ b/vpr/src/route/router_lookahead.cpp
@@ -1,6 +1,7 @@
 #include "router_lookahead.h"
 
 #include "router_lookahead_map.h"
+#include "connection_box_lookahead_map.h"
 #include "vpr_error.h"
 #include "globals.h"
 #include "route_timing.h"
@@ -8,17 +9,39 @@
 static int get_expected_segs_to_target(int inode, int target_node, int* num_segs_ortho_dir_ptr);
 static int round_up(float x);
 
-std::unique_ptr<RouterLookahead> make_router_lookahead(e_router_lookahead router_lookahead_type) {
+static std::unique_ptr<RouterLookahead> make_router_lookahead_object(e_router_lookahead router_lookahead_type) {
     if (router_lookahead_type == e_router_lookahead::CLASSIC) {
         return std::make_unique<ClassicLookahead>();
     } else if (router_lookahead_type == e_router_lookahead::MAP) {
         return std::make_unique<MapLookahead>();
+    } else if (router_lookahead_type == e_router_lookahead::CONNECTION_BOX_MAP) {
+        return std::make_unique<ConnectionBoxMapLookahead>();
     } else if (router_lookahead_type == e_router_lookahead::NO_OP) {
         return std::make_unique<NoOpLookahead>();
     }
 
     VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Unrecognized router lookahead type");
     return nullptr;
+}
+
+std::unique_ptr<RouterLookahead> make_router_lookahead(
+    e_router_lookahead router_lookahead_type,
+    std::string write_lookahead,
+    std::string read_lookahead,
+    const std::vector<t_segment_inf>& segment_inf) {
+    std::unique_ptr<RouterLookahead> router_lookahead = make_router_lookahead_object(router_lookahead_type);
+
+    if (read_lookahead.empty()) {
+        router_lookahead->compute(segment_inf);
+    } else {
+        router_lookahead->read(read_lookahead);
+    }
+
+    if (!write_lookahead.empty()) {
+        router_lookahead->write(write_lookahead);
+    }
+
+    return router_lookahead;
 }
 
 float ClassicLookahead::get_expected_cost(int current_node, int target_node, const t_conn_cost_params& params, float R_upstream) const {
@@ -79,6 +102,10 @@ float MapLookahead::get_expected_cost(int current_node, int target_node, const t
     } else { /* Change this if you want to investigate route-throughs */
         return (0.);
     }
+}
+
+void MapLookahead::compute(const std::vector<t_segment_inf>& segment_inf) {
+    compute_router_lookahead(segment_inf.size());
 }
 
 float NoOpLookahead::get_expected_cost(int /*current_node*/, int /*target_node*/, const t_conn_cost_params& /*params*/, float /*R_upstream*/) const {
@@ -168,4 +195,39 @@ static int get_expected_segs_to_target(int inode, int target_node, int* num_segs
     }
 
     return (num_segs_same_dir);
+}
+
+void invalidate_router_lookahead_cache() {
+    auto& router_ctx = g_vpr_ctx.mutable_routing();
+    router_ctx.cached_router_lookahead_.reset();
+    router_ctx.cached_lookahead_file_.clear();
+    router_ctx.cached_segment_inf_.clear();
+}
+
+const RouterLookahead* get_cached_router_lookahead(
+    e_router_lookahead router_lookahead_type,
+    std::string write_lookahead,
+    std::string read_lookahead,
+    const std::vector<t_segment_inf>& segment_inf) {
+    auto& router_ctx = g_vpr_ctx.routing();
+
+    // Check if cache is valid.
+    if (
+        router_ctx.cached_router_lookahead_ && read_lookahead == router_ctx.cached_lookahead_file_ && segment_inf == router_ctx.cached_segment_inf_) {
+    } else {
+        // Cache is not valid, compute cached object.
+        auto& mut_router_ctx = g_vpr_ctx.mutable_routing();
+
+        invalidate_router_lookahead_cache();
+
+        mut_router_ctx.cached_router_lookahead_ = make_router_lookahead(
+            router_lookahead_type,
+            write_lookahead,
+            read_lookahead,
+            segment_inf);
+        mut_router_ctx.cached_lookahead_file_ = read_lookahead;
+        mut_router_ctx.cached_segment_inf_ = segment_inf;
+    }
+
+    return router_ctx.cached_router_lookahead_.get();
 }

--- a/vpr/src/route/router_lookahead.h
+++ b/vpr/src/route/router_lookahead.h
@@ -2,21 +2,67 @@
 #define VPR_ROUTER_LOOKAHEAD_H
 #include <memory>
 #include "vpr_types.h"
+#include "vpr_error.h"
 
 struct t_conn_cost_params; //Forward declaration
 
 class RouterLookahead {
   public:
+    // Get expected cost from node to target_node.
+    //
+    // Either compute or read methods must be invoked before invoking
+    // get_expected_cost.
     virtual float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const = 0;
+
+    // Compute router lookahead (if needed).
+    virtual void compute(const std::vector<t_segment_inf>& segment_inf) = 0;
+
+    // Read router lookahead data (if any) from specified file.
+    // May be unimplemented, in which case method should throw an exception.
+    virtual void read(const std::string& file) = 0;
+
+    // Write router lookahead data (if any) to specified file.
+    // May be unimplemented, in which case method should throw an exception.
+    virtual void write(const std::string& file) const = 0;
 
     virtual ~RouterLookahead() {}
 };
 
-std::unique_ptr<RouterLookahead> make_router_lookahead(e_router_lookahead router_lookahead_type);
+// Force creation of lookahead object.
+//
+// This may involve recomputing the lookahead, so only use if lookahead cache
+// cannot be used.
+std::unique_ptr<RouterLookahead> make_router_lookahead(
+    e_router_lookahead router_lookahead_type,
+    std::string write_lookahead,
+    std::string read_lookahead,
+    const std::vector<t_segment_inf>& segment_inf);
+
+// Clear router lookahead cache (e.g. when changing or free rrgraph).
+void invalidate_router_lookahead_cache();
+
+// Returns lookahead for given rr graph.
+//
+// Object is cached in RouterContext, but access to cached object should
+// performed via this function.
+const RouterLookahead* get_cached_router_lookahead(
+    e_router_lookahead router_lookahead_type,
+    std::string write_lookahead,
+    std::string read_lookahead,
+    const std::vector<t_segment_inf>& segment_inf);
 
 class ClassicLookahead : public RouterLookahead {
   public:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    void compute(const std::vector<t_segment_inf>& /*segment_inf*/) override {
+    }
+
+    void read(const std::string& /*file*/) override {
+        VPR_THROW(VPR_ERROR_ROUTE, "ClassicLookahead::read unimplemented");
+    }
+    void write(const std::string& /*file*/) const override {
+        VPR_THROW(VPR_ERROR_ROUTE, "ClassicLookahead::write unimplemented");
+    }
 
   private:
     float classic_wire_lookahead_cost(int node, int target_node, float criticality, float R_upstream) const;
@@ -25,11 +71,26 @@ class ClassicLookahead : public RouterLookahead {
 class MapLookahead : public RouterLookahead {
   protected:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    void compute(const std::vector<t_segment_inf>& segment_inf) override;
+    void read(const std::string& /*file*/) override {
+        VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::read unimplemented");
+    }
+    void write(const std::string& /*file*/) const override {
+        VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::write unimplemented");
+    }
 };
 
 class NoOpLookahead : public RouterLookahead {
   protected:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    void compute(const std::vector<t_segment_inf>& /*segment_inf*/) override {
+    }
+    void read(const std::string& /*file*/) override {
+        VPR_THROW(VPR_ERROR_ROUTE, "Read not supported for NoOpLookahead");
+    }
+    void write(const std::string& /*file*/) const override {
+        VPR_THROW(VPR_ERROR_ROUTE, "Write not supported for NoOpLookahead");
+    }
 };
 
 #endif

--- a/vpr/src/route/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead_map_utils.cpp
@@ -1,0 +1,192 @@
+#include "router_lookahead_map_utils.h"
+
+#include "globals.h"
+#include "vpr_context.h"
+#include "vtr_math.h"
+
+/* Number of CLBs I think the average conn. goes. */
+static const int CLB_DIST = 3;
+
+util::PQ_Entry::PQ_Entry(
+    int set_rr_node_ind,
+    int switch_ind,
+    float parent_delay,
+    float parent_R_upstream,
+    float parent_congestion_upstream,
+    bool starting_node) {
+    this->rr_node_ind = set_rr_node_ind;
+
+    auto& device_ctx = g_vpr_ctx.device();
+    this->delay = parent_delay;
+    this->congestion_upstream = parent_congestion_upstream;
+    this->R_upstream = parent_R_upstream;
+    if (!starting_node) {
+        int cost_index = device_ctx.rr_nodes[set_rr_node_ind].cost_index();
+
+        float Tsw = device_ctx.rr_switch_inf[switch_ind].Tdel;
+        float Rsw = device_ctx.rr_switch_inf[switch_ind].R;
+        float Cnode = device_ctx.rr_nodes[set_rr_node_ind].C();
+        float Rnode = device_ctx.rr_nodes[set_rr_node_ind].R();
+
+        float T_linear = 0.f;
+        float T_quadratic = 0.f;
+        if (device_ctx.rr_switch_inf[switch_ind].buffered()) {
+            T_linear = Tsw + Rsw * Cnode + 0.5 * Rnode * Cnode;
+            T_quadratic = 0.;
+        } else { /* Pass transistor */
+            T_linear = Tsw + 0.5 * Rsw * Cnode;
+            T_quadratic = (Rsw + Rnode) * 0.5 * Cnode;
+        }
+
+        float base_cost;
+        if (device_ctx.rr_indexed_data[cost_index].inv_length < 0) {
+            base_cost = device_ctx.rr_indexed_data[cost_index].base_cost;
+        } else {
+            float frac_num_seg = CLB_DIST * device_ctx.rr_indexed_data[cost_index].inv_length;
+
+            base_cost = frac_num_seg * T_linear
+                        + frac_num_seg * frac_num_seg * T_quadratic;
+        }
+
+        VTR_ASSERT(T_linear >= 0.);
+        VTR_ASSERT(base_cost >= 0.);
+        this->delay += T_linear;
+
+        this->congestion_upstream += base_cost;
+    }
+
+    /* set the cost of this node */
+    this->cost = this->delay;
+}
+
+/* returns cost entry with the smallest delay */
+Cost_Entry Expansion_Cost_Entry::get_smallest_entry() const {
+    Cost_Entry smallest_entry;
+
+    for (auto entry : this->cost_vector) {
+        if (!smallest_entry.valid() || entry.delay < smallest_entry.delay) {
+            smallest_entry = entry;
+        }
+    }
+
+    return smallest_entry;
+}
+
+/* returns a cost entry that represents the average of all the recorded entries */
+Cost_Entry Expansion_Cost_Entry::get_average_entry() const {
+    float avg_delay = 0;
+    float avg_congestion = 0;
+
+    for (auto cost_entry : this->cost_vector) {
+        avg_delay += cost_entry.delay;
+        avg_congestion += cost_entry.congestion;
+    }
+
+    avg_delay /= (float)this->cost_vector.size();
+    avg_congestion /= (float)this->cost_vector.size();
+
+    return Cost_Entry(avg_delay, avg_congestion);
+}
+
+/* returns a cost entry that represents the geomean of all the recorded entries */
+Cost_Entry Expansion_Cost_Entry::get_geomean_entry() const {
+    float geomean_delay = 0;
+    float geomean_cong = 0;
+    for (auto cost_entry : this->cost_vector) {
+        geomean_delay += log(cost_entry.delay);
+        geomean_cong += log(cost_entry.congestion);
+    }
+
+    geomean_delay = exp(geomean_delay / (float)this->cost_vector.size());
+    geomean_cong = exp(geomean_cong / (float)this->cost_vector.size());
+
+    return Cost_Entry(geomean_delay, geomean_cong);
+}
+
+/* returns a cost entry that represents the medial of all recorded entries */
+Cost_Entry Expansion_Cost_Entry::get_median_entry() const {
+    /* find median by binning the delays of all entries and then chosing the bin
+     * with the largest number of entries */
+
+    int num_bins = 10;
+
+    /* find entries with smallest and largest delays */
+    Cost_Entry min_del_entry;
+    Cost_Entry max_del_entry;
+    for (auto entry : this->cost_vector) {
+        if (!min_del_entry.valid() || entry.delay < min_del_entry.delay) {
+            min_del_entry = entry;
+        }
+        if (!max_del_entry.valid() || entry.delay > max_del_entry.delay) {
+            max_del_entry = entry;
+        }
+    }
+
+    /* get the bin size */
+    float delay_diff = max_del_entry.delay - min_del_entry.delay;
+    float bin_size = delay_diff / (float)num_bins;
+
+    /* sort the cost entries into bins */
+    std::vector<std::vector<Cost_Entry> > entry_bins(num_bins, std::vector<Cost_Entry>());
+    for (auto entry : this->cost_vector) {
+        float bin_num = floor((entry.delay - min_del_entry.delay) / bin_size);
+
+        VTR_ASSERT(vtr::nint(bin_num) >= 0 && vtr::nint(bin_num) <= num_bins);
+        if (vtr::nint(bin_num) == num_bins) {
+            /* largest entry will otherwise have an out-of-bounds bin number */
+            bin_num -= 1;
+        }
+        entry_bins[vtr::nint(bin_num)].push_back(entry);
+    }
+
+    /* find the bin with the largest number of elements */
+    int largest_bin = 0;
+    int largest_size = 0;
+    for (int ibin = 0; ibin < num_bins; ibin++) {
+        if (entry_bins[ibin].size() > (unsigned)largest_size) {
+            largest_bin = ibin;
+            largest_size = (unsigned)entry_bins[ibin].size();
+        }
+    }
+
+    /* get the representative delay of the largest bin */
+    Cost_Entry representative_entry = entry_bins[largest_bin][0];
+
+    return representative_entry;
+}
+
+/* iterates over the children of the specified node and selectively pushes them onto the priority queue */
+void expand_dijkstra_neighbours(util::PQ_Entry parent_entry,
+                                std::vector<float>& node_visited_costs,
+                                std::vector<bool>& node_expanded,
+                                std::priority_queue<util::PQ_Entry>& pq) {
+    auto& device_ctx = g_vpr_ctx.device();
+
+    int parent_ind = parent_entry.rr_node_ind;
+
+    auto& parent_node = device_ctx.rr_nodes[parent_ind];
+
+    for (int iedge = 0; iedge < parent_node.num_edges(); iedge++) {
+        int child_node_ind = parent_node.edge_sink_node(iedge);
+        int switch_ind = parent_node.edge_switch(iedge);
+
+        /* skip this child if it has already been expanded from */
+        if (node_expanded[child_node_ind]) {
+            continue;
+        }
+
+        util::PQ_Entry child_entry(child_node_ind, switch_ind, parent_entry.delay,
+                                   parent_entry.R_upstream, parent_entry.congestion_upstream, false);
+
+        VTR_ASSERT(child_entry.cost >= 0);
+
+        /* skip this child if it has been visited with smaller cost */
+        if (node_visited_costs[child_node_ind] >= 0 && node_visited_costs[child_node_ind] < child_entry.cost) {
+            continue;
+        }
+
+        /* finally, record the cost with which the child was visited and put the child entry on the queue */
+        node_visited_costs[child_node_ind] = child_entry.cost;
+        pq.push(child_entry);
+    }
+}

--- a/vpr/src/route/router_lookahead_map_utils.h
+++ b/vpr/src/route/router_lookahead_map_utils.h
@@ -1,0 +1,144 @@
+#ifndef ROUTER_LOOKAHEAD_MAP_UTILS_H_
+#define ROUTER_LOOKAHEAD_MAP_UTILS_H_
+/*
+ * The router lookahead provides an estimate of the cost from an intermediate node to the target node
+ * during directed (A*-like) routing.
+ *
+ * The VPR 7.0 lookahead (route/route_timing.c ==> get_timing_driven_expected_cost) lower-bounds the remaining delay and
+ * congestion by assuming that a minimum number of wires, of the same type as the current node being expanded, can be used
+ * to complete the route. While this method is efficient, it can run into trouble with architectures that use
+ * multiple interconnected wire types.
+ *
+ * The lookahead in this file pre-computes delay/congestion costs up and to the right of a starting tile. This generates
+ * delay/congestion tables for {CHANX, CHANY} channel types, over all wire types defined in the architecture file.
+ * See Section 3.2.4 in Oleg Petelin's MASc thesis (2016) for more discussion.
+ *
+ */
+
+#include <cmath>
+#include <limits>
+#include <vector>
+#include <queue>
+#include "vpr_types.h"
+
+/* when a list of delay/congestion entries at a coordinate in Cost_Entry is boiled down to a single
+ * representative entry, this enum is passed-in to specify how that representative entry should be
+ * calculated */
+enum e_representative_entry_method {
+    FIRST = 0, //the first cost that was recorded
+    SMALLEST,  //the smallest-delay cost recorded
+    AVERAGE,
+    GEOMEAN,
+    MEDIAN
+};
+
+/* f_cost_map is an array of these cost entries that specifies delay/congestion estimates
+ * to travel relative x/y distances */
+class Cost_Entry {
+  public:
+    float delay;
+    float congestion;
+
+    Cost_Entry() {
+        delay = std::numeric_limits<float>::infinity();
+        congestion = std::numeric_limits<float>::infinity();
+    }
+    Cost_Entry(float set_delay, float set_congestion) {
+        delay = set_delay;
+        congestion = set_congestion;
+    }
+
+    bool valid() const {
+        return std::isfinite(delay) && std::isfinite(congestion);
+    }
+};
+
+/* a class that stores delay/congestion information for a given relative coordinate during the Dijkstra expansion.
+ * since it stores multiple cost entries, it is later boiled down to a single representative cost entry to be stored
+ * in the final lookahead cost map */
+class Expansion_Cost_Entry {
+  private:
+    std::vector<Cost_Entry> cost_vector;
+
+    Cost_Entry get_smallest_entry() const;
+    Cost_Entry get_average_entry() const;
+    Cost_Entry get_geomean_entry() const;
+    Cost_Entry get_median_entry() const;
+
+  public:
+    void add_cost_entry(e_representative_entry_method method,
+                        float add_delay,
+                        float add_congestion) {
+        Cost_Entry cost_entry(add_delay, add_congestion);
+        if (method == SMALLEST) {
+            /* taking the smallest-delay entry anyway, so no need to push back multple entries */
+            if (this->cost_vector.empty()) {
+                this->cost_vector.push_back(cost_entry);
+            } else {
+                if (add_delay < this->cost_vector[0].delay) {
+                    this->cost_vector[0] = cost_entry;
+                }
+            }
+        } else {
+            this->cost_vector.push_back(cost_entry);
+        }
+    }
+    void clear_cost_entries() {
+        this->cost_vector.clear();
+    }
+
+    Cost_Entry get_representative_cost_entry(e_representative_entry_method method) const {
+        Cost_Entry entry;
+
+        if (!cost_vector.empty()) {
+            switch (method) {
+                case FIRST:
+                    entry = cost_vector[0];
+                    break;
+                case SMALLEST:
+                    entry = this->get_smallest_entry();
+                    break;
+                case AVERAGE:
+                    entry = this->get_average_entry();
+                    break;
+                case GEOMEAN:
+                    entry = this->get_geomean_entry();
+                    break;
+                case MEDIAN:
+                    entry = this->get_median_entry();
+                    break;
+                default:
+                    break;
+            }
+        }
+        return entry;
+    }
+};
+
+namespace util {
+/* a class that represents an entry in the Dijkstra expansion priority queue */
+class PQ_Entry {
+  public:
+    int rr_node_ind; //index in device_ctx.rr_nodes that this entry represents
+    float cost;      //the cost of the path to get to this node
+
+    /* store backward delay, R and congestion info */
+    float delay;
+    float R_upstream;
+    float congestion_upstream;
+
+    PQ_Entry(int set_rr_node_ind, int /*switch_ind*/, float parent_delay, float parent_R_upstream, float parent_congestion_upstream, bool starting_node);
+
+    bool operator<(const PQ_Entry& obj) const {
+        /* inserted into max priority queue so want queue entries with a lower cost to be greater */
+        return (this->cost > obj.cost);
+    }
+};
+} // namespace util
+
+void expand_dijkstra_neighbours(util::PQ_Entry parent_entry,
+                                std::vector<float>& node_visited_costs,
+                                std::vector<bool>& node_expanded,
+                                std::priority_queue<util::PQ_Entry>& pq);
+
+#endif

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -2503,6 +2503,54 @@ static vtr::NdMatrix<std::vector<int>, 4> alloc_and_load_track_to_pin_lookup(vtr
     return track_to_pin_lookup;
 }
 
+/* Writes out data (excludes fasm metadata) about node inode to binary in file fp *
+ * Writes data in the following order: int inode, t_rr_type type, e_direction     *
+ * direction (if CHANX or CHANY), uint16_t capacity, length 5 uint16_t array pos, *
+ * e_side side (if IPIN or OPIN), float R, float C, uint16_t num_edges.Then loops *
+ * through every edge writing out int edge_sink node and uint16_t edge_switch.    */
+void write_rr_node(FILE* fp, const std::vector<t_rr_node>& L_rr_node, int inode) {
+    const auto& rr_node = L_rr_node[inode];
+    t_rr_type type = rr_node.type();
+    uint16_t num_edges = rr_node.num_edges();
+    int edge_sink_node;
+    uint16_t edge_switch;
+    uint16_t capacity = (uint16_t)rr_node.capacity();
+    float R = rr_node.R();
+    float C = rr_node.C();
+    uint16_t pos[5];
+
+    pos[0] = rr_node.xlow();
+    pos[1] = rr_node.ylow();
+    pos[2] = rr_node.xhigh();
+    pos[3] = rr_node.yhigh();
+    pos[4] = rr_node.ptc_num();
+
+    fwrite(&inode, sizeof(inode), 1, fp);
+    fwrite(&type, sizeof(type), 1, fp);
+    if (rr_node.type() == CHANX || rr_node.type() == CHANY) {
+        e_direction direction = rr_node.direction();
+        fwrite(&direction, sizeof(direction), 1, fp);
+    }
+    fwrite(&capacity, sizeof(capacity), 1, fp);
+    fwrite(pos, sizeof(*pos), 5, fp);
+
+    if (rr_node.type() == IPIN || rr_node.type() == OPIN) {
+        e_side side = rr_node.side();
+        fwrite(&side, sizeof(side), 1, fp);
+    }
+
+    fwrite(&R, sizeof(R), 1, fp);
+    fwrite(&C, sizeof(C), 1, fp);
+    fwrite(&num_edges, sizeof(num_edges), 1, fp);
+
+    for (int iedge = 0; iedge < rr_node.num_edges(); ++iedge) {
+        edge_sink_node = rr_node.edge_sink_node(iedge);
+        edge_switch = rr_node.edge_switch(iedge);
+        fwrite(&edge_sink_node, sizeof(edge_sink_node), 1, fp);
+        fwrite(&edge_switch, sizeof(edge_switch), 1, fp);
+    }
+}
+
 std::string describe_rr_node(int inode) {
     auto& device_ctx = g_vpr_ctx.device();
 

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -34,6 +34,7 @@ using namespace std;
 #include "rr_graph_writer.h"
 #include "rr_graph_reader.h"
 #include "router_lookahead_map.h"
+#include "connection_box_lookahead_map.h"
 #include "rr_graph_clock.h"
 
 #include "rr_types.h"
@@ -322,7 +323,6 @@ void create_rr_graph(const t_graph_type graph_type,
                      const bool trim_empty_channels,
                      const bool trim_obs_channels,
                      const enum e_clock_modeling clock_modeling,
-                     const e_router_lookahead router_lookahead_type,
                      const t_direct_inf* directs,
                      const int num_directs,
                      int* Warnings) {
@@ -379,10 +379,6 @@ void create_rr_graph(const t_graph_type graph_type,
     process_non_config_sets(non_config_rr_sets);
 
     print_rr_graph_stats();
-
-    if (router_lookahead_type == e_router_lookahead::MAP) {
-        compute_router_lookahead(segment_inf.size());
-    }
 
     //Write out rr graph file if needed
     if (!det_routing_arch->write_rr_graph_filename.empty()) {
@@ -1385,6 +1381,8 @@ void free_rr_graph() {
     device_ctx.rr_node_metadata.clear();
 
     device_ctx.rr_edge_metadata.clear();
+
+    invalidate_router_lookahead_cache();
 }
 
 static void build_rr_sinks_sources(const int i,

--- a/vpr/src/route/rr_graph.h
+++ b/vpr/src/route/rr_graph.h
@@ -6,6 +6,9 @@
  * and so are not currently used in commercial architectures. */
 #define INCLUDE_TRACK_BUFFERS false
 
+#define BINARY_MAGIC_NUM 0x42525247
+#define BINARY_FILE_VERSION 1
+
 #include "device_grid.h"
 
 enum e_graph_type {
@@ -46,6 +49,9 @@ void free_rr_graph();
 
 //Returns a brief one-line summary of an RR node
 std::string describe_rr_node(int inode);
+
+void print_rr_node(FILE* fp, const std::vector<t_rr_node>& L_rr_node, int inode);
+void write_rr_node(FILE* fp, const std::vector<t_rr_node>& L_rr_node, int inode);
 
 void init_fan_in(std::vector<t_rr_node>& L_rr_node, const int num_rr_nodes);
 

--- a/vpr/src/route/rr_graph.h
+++ b/vpr/src/route/rr_graph.h
@@ -37,7 +37,6 @@ void create_rr_graph(const t_graph_type graph_type,
                      const bool trim_empty_channels,
                      const bool trim_obs_channels,
                      const enum e_clock_modeling clock_modeling,
-                     const e_router_lookahead router_lookahead_type,
                      const t_direct_inf* directs,
                      const int num_directs,
                      int* Warnings);

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -55,12 +55,14 @@ void verify_segments(pugi::xml_node parent, const pugiutil::loc_data& loc_data, 
 void verify_blocks(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void process_blocks(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void verify_grid(pugi::xml_node parent, const pugiutil::loc_data& loc_data, const DeviceGrid& grid);
+void process_nodes_and_switches_bin(FILE* fp, int* wire_to_rr_ipin_switch, bool is_global_graph, const std::vector<t_segment_inf>& segment_inf, int numSwitches);
 void process_nodes(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void process_edges(pugi::xml_node parent, const pugiutil::loc_data& loc_data, int* wire_to_rr_ipin_switch, const int num_rr_switches);
 void process_channels(t_chan_width& chan_width, pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void process_rr_node_indices(const DeviceGrid& grid);
 void process_seg_id(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void set_cost_indices(pugi::xml_node parent, const pugiutil::loc_data& loc_data, const bool is_global_graph, const int num_seg_types);
+void set_cost_index_bin(int inode, t_rr_type node_type, const bool is_global_graph, const int num_seg_types, short seg_id);
 
 /************************ Subroutine definitions ****************************/
 
@@ -140,14 +142,6 @@ void load_rr_file(const t_graph_type graph_type,
         int max_chan_width = (is_global_graph ? 1 : nodes_per_chan.max);
         VTR_ASSERT(max_chan_width > 0);
 
-        /* Alloc rr nodes and count count nodes */
-        next_component = get_single_child(rr_graph, "rr_nodes", loc_data);
-
-        int num_rr_nodes = count_children(next_component, "node", loc_data);
-
-        device_ctx.rr_nodes.resize(num_rr_nodes);
-        process_nodes(next_component, loc_data);
-
         /* Loads edges, switches, and node look up tables*/
         next_component = get_single_child(rr_graph, "switches", loc_data);
 
@@ -155,26 +149,53 @@ void load_rr_file(const t_graph_type graph_type,
         device_ctx.rr_switch_inf.resize(numSwitches);
 
         process_switches(next_component, loc_data);
+        /* Branches to binary format */
+        next_component = get_single_child(rr_graph, "binary_nodes_and_edges", loc_data, OPTIONAL);
+        if (next_component) {
+            auto filename = get_attribute(next_component, "file", loc_data).as_string("");
+            VTR_LOG("Using Binary File: %s\n", filename);
+            FILE* fp = fopen(filename, "rb");
+            if (fp == NULL) {
+                VPR_THROW(VPR_ERROR_OTHER, "Binary File %s Does Not Exist\n", filename);
+            }
 
-        next_component = get_single_child(rr_graph, "rr_edges", loc_data);
-        process_edges(next_component, loc_data, wire_to_rr_ipin_switch, numSwitches);
+            process_nodes_and_switches_bin(fp, wire_to_rr_ipin_switch, is_global_graph, segment_inf, numSwitches);
 
-        //Partition the rr graph edges for efficient access to configurable/non-configurable
-        //edge subsets. Must be done after RR switches have been allocated
-        partition_rr_graph_edges(device_ctx);
+            partition_rr_graph_edges(device_ctx);
+            process_rr_node_indices(grid);
+            init_fan_in(device_ctx.rr_nodes, device_ctx.rr_nodes.size());
+            alloc_and_load_rr_indexed_data(segment_inf, device_ctx.rr_node_indices,
+                                           max_chan_width, *wire_to_rr_ipin_switch, base_cost_type);
 
-        process_rr_node_indices(grid);
+        } else {
+            /* Alloc rr nodes and count count nodes */
+            next_component = get_single_child(rr_graph, "rr_nodes", loc_data);
 
-        init_fan_in(device_ctx.rr_nodes, device_ctx.rr_nodes.size());
+            int num_rr_nodes = count_children(next_component, "node", loc_data);
 
-        //sets the cost index and seg id information
-        next_component = get_single_child(rr_graph, "rr_nodes", loc_data);
-        set_cost_indices(next_component, loc_data, is_global_graph, segment_inf.size());
+            device_ctx.rr_nodes.resize(num_rr_nodes);
+            process_nodes(next_component, loc_data);
 
-        alloc_and_load_rr_indexed_data(segment_inf, device_ctx.rr_node_indices,
-                                       max_chan_width, *wire_to_rr_ipin_switch, base_cost_type);
+            next_component = get_single_child(rr_graph, "rr_edges", loc_data);
+            process_edges(next_component, loc_data, wire_to_rr_ipin_switch, numSwitches);
 
-        process_seg_id(next_component, loc_data);
+            //Partition the rr graph edges for efficient access to configurable/non-configurable
+            //edge subsets. Must be done after RR switches have been allocated
+            partition_rr_graph_edges(device_ctx);
+
+            process_rr_node_indices(grid);
+
+            init_fan_in(device_ctx.rr_nodes, device_ctx.rr_nodes.size());
+
+            //sets the cost index and seg id information
+            next_component = get_single_child(rr_graph, "rr_nodes", loc_data);
+            set_cost_indices(next_component, loc_data, is_global_graph, segment_inf.size());
+
+            alloc_and_load_rr_indexed_data(segment_inf, device_ctx.rr_node_indices,
+                                           max_chan_width, *wire_to_rr_ipin_switch, base_cost_type);
+
+            process_seg_id(next_component, loc_data);
+        }
 
         device_ctx.chan_width = nodes_per_chan;
 
@@ -182,6 +203,103 @@ void load_rr_file(const t_graph_type graph_type,
 
     } catch (XmlError& e) {
         vpr_throw(VPR_ERROR_ROUTE, read_rr_graph_name, e.line(), "%s", e.what());
+    }
+}
+
+void process_nodes_and_switches_bin(FILE* fp,
+                                    int* wire_to_rr_ipin_switch,
+                                    bool is_global_graph,
+                                    const std::vector<t_segment_inf>& segment_inf,
+                                    int numSwitches) {
+    auto& device_ctx = g_vpr_ctx.mutable_device();
+    uint32_t magic_num;
+    uint16_t format_version;
+    uint16_t header_length;
+    uint64_t num_rr_nodes;
+    fread_secure(&magic_num, sizeof(magic_num), 1, fp);
+    fread_secure(&format_version, sizeof(format_version), 1, fp);
+    fread_secure(&header_length, sizeof(header_length), 1, fp);
+    char* header = new char[header_length + 1];
+    header[header_length] = '\0';
+    fread_secure(header, sizeof(char), header_length, fp);
+    fread_secure(&num_rr_nodes, sizeof(num_rr_nodes), 1, fp);
+    device_ctx.rr_nodes.resize(num_rr_nodes);
+
+    if (magic_num != BINARY_MAGIC_NUM) {
+        VTR_LOG_WARN("Not a VPR Binary rr_graph file\n");
+    }
+
+    if (format_version != BINARY_FILE_VERSION) {
+        VTR_LOG_WARN("Binary file format versions do not match\n");
+    }
+
+    int inode;
+    t_rr_type node_type;
+    uint16_t num_edges;
+    e_direction direction;
+    e_side side;
+    int edge_sink_node;
+    uint16_t edge_switch;
+    uint16_t capacity;
+    float R;
+    float C;
+    uint16_t pos[5];
+
+    for (uint64_t i = 0; i < num_rr_nodes; i++) {
+        fread_secure(&inode, sizeof(inode), 1, fp);
+        fread_secure(&node_type, sizeof(node_type), 1, fp);
+        auto& node = device_ctx.rr_nodes[inode];
+        node.set_type(node_type);
+        if (node.type() == CHANX || node.type() == CHANY) {
+            fread_secure(&direction, sizeof(direction), 1, fp);
+            node.set_direction(direction);
+        }
+
+        fread_secure(&capacity, sizeof(capacity), 1, fp);
+        if (capacity > 0)
+            node.set_capacity(capacity);
+        fread_secure(pos, sizeof(*pos), 5, fp);
+        node.set_coordinates(pos[0], pos[1], pos[2], pos[3]);
+        node.set_ptc_num(pos[4]);
+        if (node.type() == IPIN || node.type() == OPIN) {
+            fread_secure(&side, sizeof(side), 1, fp);
+            node.set_side(side);
+        }
+
+        fread_secure(&R, sizeof(R), 1, fp);
+        fread_secure(&C, sizeof(C), 1, fp);
+        node.set_rc_index(find_create_rr_rc_data(R, C));
+
+        fread_secure(&num_edges, sizeof(num_edges), 1, fp);
+
+        node.set_num_edges(num_edges);
+        for (int j = 0; j < num_edges; j++) {
+            fread_secure(&edge_sink_node, sizeof(edge_sink_node), 1, fp);
+            fread_secure(&edge_switch, sizeof(edge_switch), 1, fp);
+            node.set_edge_sink_node(j, edge_sink_node);
+            node.set_edge_switch(j, edge_switch);
+        }
+        set_cost_index_bin(inode, node_type, is_global_graph, segment_inf.size(), 0);
+    }
+    std::vector<int> count_for_wire_to_ipin_switches;
+    count_for_wire_to_ipin_switches.resize(numSwitches, 0);
+    for (uint64_t i = 0; i < num_rr_nodes; i++) {
+        auto& node = device_ctx.rr_nodes[i];
+        if (node.type() == CHANX || node.type() == CHANY) {
+            num_edges = node.num_edges();
+            for (int j = 0; j < num_edges; j++) {
+                if (device_ctx.rr_nodes[node.edge_sink_node(j)].type() == IPIN) {
+                    count_for_wire_to_ipin_switches[j]++;
+                }
+            }
+        }
+    }
+    int max = -1;
+    for (int j = 0; j < numSwitches; j++) {
+        if (count_for_wire_to_ipin_switches[j] > max) {
+            *wire_to_rr_ipin_switch = j;
+            max = count_for_wire_to_ipin_switches[j];
+        }
     }
 }
 
@@ -876,5 +994,32 @@ void set_cost_indices(pugi::xml_node parent, const pugiutil::loc_data& loc_data,
             }
         }
         rr_node = rr_node.next_sibling(rr_node.name());
+    }
+}
+
+/* This function sets the Source pins, sink pins, ipin, and opin
+ * to their unique cost index identifier. CHANX and CHANY cost indicies are set after the
+ * seg_id is read in from the rr graph */
+void set_cost_index_bin(int inode, t_rr_type node_type, const bool is_global_graph, const int num_seg_types, short seg_id) {
+    auto& device_ctx = g_vpr_ctx.mutable_device();
+    auto& node = device_ctx.rr_nodes[inode];
+    //set the cost index in order to load the segment information, rr nodes should be set already
+    if (node_type == SOURCE) {
+        node.set_cost_index(SOURCE_COST_INDEX);
+    } else if (node_type == SINK) {
+        node.set_cost_index(SINK_COST_INDEX);
+    } else if (node_type == IPIN) {
+        node.set_cost_index(IPIN_COST_INDEX);
+    } else if (node_type == OPIN) {
+        node.set_cost_index(OPIN_COST_INDEX);
+    } else if (node_type == CHANX || node_type == CHANY) {
+        /*CHANX and CHANY cost index is dependent on the segment id*/
+        if (is_global_graph) {
+            node.set_cost_index(0);
+        } else if (device_ctx.rr_nodes[inode].type() == CHANX) {
+            node.set_cost_index(CHANX_COST_INDEX_START + seg_id);
+        } else if (device_ctx.rr_nodes[inode].type() == CHANY) {
+            node.set_cost_index(CHANX_COST_INDEX_START + num_seg_types + seg_id);
+        }
     }
 }

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -56,6 +56,7 @@ void verify_blocks(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void process_blocks(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void verify_grid(pugi::xml_node parent, const pugiutil::loc_data& loc_data, const DeviceGrid& grid);
 void process_nodes(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
+void process_connection_boxes(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void process_edges(pugi::xml_node parent, const pugiutil::loc_data& loc_data, int* wire_to_rr_ipin_switch, const int num_rr_switches);
 void process_channels(t_chan_width& chan_width, pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void process_rr_node_indices(const DeviceGrid& grid);
@@ -133,6 +134,13 @@ void load_rr_file(const t_graph_type graph_type,
         next_component = get_first_child(rr_graph, "channels", loc_data);
         process_channels(nodes_per_chan, next_component, loc_data);
 
+        next_component = get_first_child(rr_graph, "connection_boxes", loc_data, OPTIONAL);
+        if (next_component != nullptr) {
+            process_connection_boxes(next_component, loc_data);
+        } else {
+            device_ctx.connection_boxes.clear();
+        }
+
         /* Decode the graph_type */
         bool is_global_graph = (GRAPH_GLOBAL == graph_type ? true : false);
 
@@ -146,6 +154,7 @@ void load_rr_file(const t_graph_type graph_type,
         int num_rr_nodes = count_children(next_component, "node", loc_data);
 
         device_ctx.rr_nodes.resize(num_rr_nodes);
+        device_ctx.connection_boxes.resize_nodes(num_rr_nodes);
         process_nodes(next_component, loc_data);
 
         /* Loads edges, switches, and node look up tables*/
@@ -179,6 +188,7 @@ void load_rr_file(const t_graph_type graph_type,
         device_ctx.chan_width = nodes_per_chan;
 
         check_rr_graph(graph_type, grid, device_ctx.block_types);
+        device_ctx.connection_boxes.create_sink_back_ref();
 
     } catch (XmlError& e) {
         vpr_throw(VPR_ERROR_ROUTE, read_rr_graph_name, e.line(), "%s", e.what());
@@ -306,6 +316,18 @@ void process_nodes(pugi::xml_node parent, const pugiutil::loc_data& loc_data) {
             node.set_type(OPIN);
         } else if (strcmp(node_type, "IPIN") == 0) {
             node.set_type(IPIN);
+
+            pugi::xml_node connection_boxSubnode = get_single_child(rr_node, "connection_box", loc_data, OPTIONAL);
+            if (connection_boxSubnode) {
+                int x = get_attribute(connection_boxSubnode, "x", loc_data).as_int();
+                int y = get_attribute(connection_boxSubnode, "y", loc_data).as_int();
+                int id = get_attribute(connection_boxSubnode, "id", loc_data).as_int();
+
+                device_ctx.connection_boxes.add_connection_box(inode,
+                                                               ConnectionBoxId(id),
+                                                               std::make_pair(x, y));
+            }
+
         } else {
             VPR_FATAL_ERROR(VPR_ERROR_OTHER,
                             "Valid inputs for class types are \"CHANX\", \"CHANY\",\"SOURCE\", \"SINK\",\"OPIN\", and \"IPIN\".");
@@ -323,6 +345,15 @@ void process_nodes(pugi::xml_node parent, const pugiutil::loc_data& loc_data) {
                 VTR_ASSERT((strcmp(correct_direction, "NO_DIR") == 0));
                 node.set_direction(NO_DIRECTION);
             }
+        }
+
+        pugi::xml_node connection_boxSubnode = get_single_child(rr_node, "canonical_loc", loc_data, OPTIONAL);
+        if (connection_boxSubnode) {
+            int x = get_attribute(connection_boxSubnode, "x", loc_data).as_int();
+            int y = get_attribute(connection_boxSubnode, "y", loc_data).as_int();
+
+            device_ctx.connection_boxes.add_canonical_loc(inode,
+                                                          std::make_pair(x, y));
         }
 
         node.set_capacity(get_attribute(rr_node, "capacity", loc_data).as_float());
@@ -877,4 +908,27 @@ void set_cost_indices(pugi::xml_node parent, const pugiutil::loc_data& loc_data,
         }
         rr_node = rr_node.next_sibling(rr_node.name());
     }
+}
+
+void process_connection_boxes(pugi::xml_node parent, const pugiutil::loc_data& loc_data) {
+    auto& device_ctx = g_vpr_ctx.mutable_device();
+
+    int x_dim = get_attribute(parent, "x_dim", loc_data).as_int(0);
+    int y_dim = get_attribute(parent, "y_dim", loc_data).as_int(0);
+    int num_boxes = get_attribute(parent, "num_boxes", loc_data).as_int(0);
+    VTR_ASSERT(num_boxes >= 0);
+
+    pugi::xml_node connection_box = get_first_child(parent, "connection_box", loc_data);
+    std::vector<ConnectionBox> boxes(num_boxes);
+    while (connection_box) {
+        int id = get_attribute(connection_box, "id", loc_data).as_int(-1);
+        const char* name = get_attribute(connection_box, "name", loc_data).as_string(nullptr);
+        VTR_ASSERT(id >= 0 && id < num_boxes);
+        VTR_ASSERT(boxes.at(id).name == "");
+        boxes.at(id).name = std::string(name);
+
+        connection_box = connection_box.next_sibling(connection_box.name());
+    }
+
+    device_ctx.connection_boxes.reset_boxes(std::make_pair(x_dim, y_dim), boxes);
 }

--- a/vpr/src/route/rr_graph_writer.cpp
+++ b/vpr/src/route/rr_graph_writer.cpp
@@ -5,6 +5,7 @@
  * children tags such as timing, location, or some general
  * details. Each tag has attributes to describe them */
 
+#include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <string.h>
@@ -15,6 +16,7 @@
 #include "read_xml_arch_file.h"
 #include "vtr_version.h"
 #include "rr_graph_writer.h"
+#include "rr_graph.h"
 
 using namespace std;
 
@@ -37,6 +39,16 @@ void write_rr_segments(fstream& fp, const std::vector<t_segment_inf>& segment_in
 /* This function is used to write the rr_graph into xml format into a a file with name: file_name */
 void write_rr_graph(const char* file_name, const std::vector<t_segment_inf>& segment_inf) {
     fstream fp;
+    FILE* fb = nullptr;
+    std::stringstream header;
+    std::string filename_str(file_name);
+    bool binary_mode = (filename_str.substr(filename_str.length() - 7) == "bin.xml");
+    std::string bin_file_name;
+    if (binary_mode) {
+        bin_file_name = filename_str.substr(0, filename_str.length() - 4);
+        VTR_LOG("RR_Graph binary file %s\n", bin_file_name.c_str());
+        fb = vtr::fopen(bin_file_name.c_str(), "w");
+    }
     fp.open(file_name, fstream::out | fstream::trunc);
 
     /* Prints out general info for easy error checking*/
@@ -45,8 +57,9 @@ void write_rr_graph(const char* file_name, const std::vector<t_segment_inf>& seg
                         "couldn't open file \"%s\" for generating RR graph file\n", file_name);
     }
     cout << "Writing RR graph" << endl;
-    fp << "<rr_graph tool_name=\"vpr\" tool_version=\"" << vtr::VERSION << "\" tool_comment=\"Generated from arch file "
-       << get_arch_file_name() << "\">" << endl;
+    header << "<rr_graph tool_name=\"vpr\" tool_version=\"" << vtr::VERSION << "\" tool_comment=\"Generated from arch file "
+           << get_arch_file_name() << "\">" << endl;
+    fp << header.rdbuf();
 
     /* Write out each individual component*/
     write_rr_channel(fp);
@@ -54,9 +67,31 @@ void write_rr_graph(const char* file_name, const std::vector<t_segment_inf>& seg
     write_rr_segments(fp, segment_inf);
     write_rr_block_types(fp);
     write_rr_grid(fp);
-    write_rr_node(fp);
-    write_rr_edges(fp);
-    fp << "</rr_graph>";
+    if (binary_mode) {
+        fp << "	<binary_nodes_and_edges file=\"" << bin_file_name << "\"/>\n";
+        auto& device_ctx = g_vpr_ctx.device();
+        const std::string header_s = header.str();
+        const char* header_c = header_s.c_str();
+        uint32_t magic_num = BINARY_MAGIC_NUM;
+        uint16_t format_version = BINARY_FILE_VERSION;
+        uint16_t header_length = header_s.length();
+        uint64_t num_rr_nodes = (uint64_t)device_ctx.rr_nodes.size();
+        VTR_LOG("RR_Graph binary mode\n");
+        printf("Header length: %d\n", header_length);
+        fwrite(&magic_num, sizeof(magic_num), 1, fb);
+        fwrite(&format_version, sizeof(format_version), 1, fb);
+        fwrite(&header_length, sizeof(header_length), 1, fb);
+        fwrite(&header_c, sizeof(char), header_length, fb);
+        fwrite(&num_rr_nodes, sizeof(num_rr_nodes), 1, fb);
+        for (size_t inode = 0; inode < num_rr_nodes; inode++) {
+            write_rr_node(fb, device_ctx.rr_nodes, inode);
+        }
+        fclose(fb);
+    } else {
+        write_rr_node(fp);
+        write_rr_edges(fp);
+    }
+    fp << "</rr_graph>\n";
 
     fp.close();
 

--- a/vpr/src/route/rr_node.h
+++ b/vpr/src/route/rr_node.h
@@ -173,7 +173,7 @@ class t_rr_node {
     uint16_t edges_capacity_ = 0;
     uint8_t num_non_configurable_edges_ = 0;
 
-    int8_t cost_index_ = -1;
+    uint16_t cost_index_ = -1;
     int16_t rc_index_ = -1;
 
     int16_t xlow_ = -1;

--- a/vpr/src/timing/timing_util.cpp
+++ b/vpr/src/timing/timing_util.cpp
@@ -571,6 +571,10 @@ float calc_relaxed_criticality(const std::map<DomainPair, float>& domains_max_re
             max_req += shift;
         }
 
+        if (!std::isfinite(slack)) {
+            continue;
+        }
+
         float crit = std::numeric_limits<float>::quiet_NaN();
         if (max_req > 0.) {
             //Standard case

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -2042,6 +2042,15 @@ static int convert_switch_index(int* switch_index, int* fanin) {
     return -1;
 }
 
+void fread_secure(void* var, size_t size, unsigned int count, FILE* fp) {
+    auto result = fread(var, size, count, fp);
+    if (result != count) {
+        VPR_THROW(VPR_ERROR_OTHER, "ERROR reading file\n");
+    }
+
+    return;
+}
+
 /*
  * print out number of usage for every switch (type / fanin combination)
  * (referring to rr_graph.c: alloc_rr_switch_inf())

--- a/vpr/src/util/vpr_utils.h
+++ b/vpr/src/util/vpr_utils.h
@@ -37,6 +37,8 @@ void get_pin_range_for_block(const ClusterBlockId blk_id,
 
 void sync_grid_to_blocks();
 
+void fread_secure(void* var, size_t size, unsigned int count, FILE* fp);
+
 //Returns the name of the pin_index'th pin on the specified block type
 std::string block_type_pin_index_to_name(t_type_ptr type, int pin_index);
 

--- a/vpr/test/test_place_delay_model_serdes.cpp
+++ b/vpr/test/test_place_delay_model_serdes.cpp
@@ -1,0 +1,87 @@
+#include "catch.hpp"
+
+#include "place_delay_model.h"
+
+namespace {
+
+#ifdef VTR_ENABLE_CAPNPROTO
+static constexpr const char kDeltaDelayBin[] = "test_delta_delay.bin";
+static constexpr const char kOverrideDelayBin[] = "test_override_delay.bin";
+
+TEST_CASE("round_trip_delta_delay_model", "[vpr]") {
+    constexpr size_t kDimX = 10;
+    constexpr size_t kDimY = 10;
+    vtr::Matrix<float> delays;
+    delays.resize({kDimX, kDimY});
+
+    for (size_t x = 0; x < kDimX; ++x) {
+        for (size_t y = 0; y < kDimY; ++y) {
+            delays[x][y] = (x + 1) * (y + 1);
+        }
+    }
+    DeltaDelayModel model(std::move(delays));
+    const auto& delays1 = model.delays();
+
+    model.write(kDeltaDelayBin);
+
+    DeltaDelayModel model2;
+    model2.read(kDeltaDelayBin);
+
+    const auto& delays2 = model2.delays();
+
+    REQUIRE(delays1.size() == delays2.size());
+    REQUIRE(delays1.ndims() == delays2.ndims());
+    for (size_t dim = 0; dim < delays1.ndims(); ++dim) {
+        REQUIRE(delays1.dim_size(dim) == delays2.dim_size(dim));
+    }
+
+    for (size_t x = 0; x < kDimX; ++x) {
+        for (size_t y = 0; y < kDimY; ++y) {
+            CHECK(delays1[x][y] == delays2[x][y]);
+        }
+    }
+}
+
+TEST_CASE("round_trip_override_delay_model", "[vpr]") {
+    constexpr size_t kDimX = 10;
+    constexpr size_t kDimY = 10;
+    vtr::Matrix<float> delays;
+    delays.resize({kDimX, kDimY});
+
+    for (size_t x = 0; x < kDimX; ++x) {
+        for (size_t y = 0; y < kDimY; ++y) {
+            delays[x][y] = (x + 1) * (y + 1);
+        }
+    }
+    OverrideDelayModel model;
+    auto base_model = std::make_unique<DeltaDelayModel>(delays);
+    model.set_base_delay_model(std::move(base_model));
+    model.set_delay_override(1, 2, 3, 4, 5, 6, -1);
+    model.set_delay_override(2, 2, 3, 4, 5, 6, -2);
+
+    model.write(kOverrideDelayBin);
+
+    OverrideDelayModel model2;
+    model2.read(kOverrideDelayBin);
+
+    const auto& delays1 = model.base_delay_model()->delays();
+    const auto& delays2 = model2.base_delay_model()->delays();
+
+    REQUIRE(delays1.size() == delays2.size());
+    REQUIRE(delays1.ndims() == delays2.ndims());
+    for (size_t dim = 0; dim < delays1.ndims(); ++dim) {
+        REQUIRE(delays1.dim_size(dim) == delays2.dim_size(dim));
+    }
+
+    for (size_t x = 0; x < kDimX; ++x) {
+        for (size_t y = 0; y < kDimY; ++y) {
+            CHECK(delays1[x][y] == delays2[x][y]);
+        }
+    }
+
+    CHECK(model2.get_delay_override(1, 2, 3, 4, 5, 6) == -1);
+    CHECK(model2.get_delay_override(2, 2, 3, 4, 5, 6) == -2);
+}
+#endif
+
+} // namespace


### PR DESCRIPTION
This PR fixes unrelated packing:

The `unclustered_list_head` is an array holding heads of lists of unclustered molecules. The array is sorted by number of molecules inputs. Since the `unclustered_list_head_size` was calculated incorrectly, the molecules with highest input count were not considered while searching for unrelated candidates for a cluster.

This issue is one of the reasons https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/621 fails.

It also hits us in https://github.com/SymbiFlow/symbiflow-arch-defs/pull/703

I'm opening this PR here so we can discuss it, but it eventually should go upstream