### PR TITLE
Sample costs using one rr_node per segment type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ option(VTR_ENABLE_SANITIZE "Enable address/leak/undefined-behaviour sanitizers (
 option(VTR_ENABLE_PROFILING "Enable performance profiler (gprof)" OFF)
 option(VTR_ENABLE_COVERAGE "Enable code coverage tracking (gcov)" OFF)
 option(VTR_ENABLE_DEBUG_LOGGING "Enable debug logging" OFF)
+option(VTR_ENABLE_CAPNPROTO "Enable capnproto binary serialization support in VPR." ON)
 
 #Allow the user to decide weather to compile the graphics library
 set(VPR_USE_EZGL "auto" CACHE STRING "Specify whether vpr uses the graphics library")
@@ -276,8 +277,13 @@ endif()
 #
 # Set final flags
 #
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARN_FLAGS} ${SANITIZE_FLAGS} ${PROFILING_FLAGS} ${COVERAGE_FLAGS} ${LOGGING_FLAGS} ${COLORED_COMPILE}")
-message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+separate_arguments(
+    ADDITIONAL_FLAGS UNIX_COMMAND "${SANITIZE_FLAGS} ${PROFILING_FLAGS} ${COVERAGE_FLAGS} ${LOGGING_FLAGS} ${COLORED_COMPILE}"
+    )
+add_compile_options(${ADDITIONAL_FLAGS})
+separate_arguments(
+    WARN_FLAGS UNIX_COMMAND "${WARN_FLAGS}"
+    )
 
 
 #
@@ -329,6 +335,9 @@ endif()
 
 #Add the various sub-projects
 add_subdirectory(libs)
+
+# Only add warn flags for VPR internal libraries.
+add_compile_options(${WARN_FLAGS})
 add_subdirectory(vpr)
 add_subdirectory(abc)
 add_subdirectory(ODIN_II)

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,9 +1,14 @@
-#VTR developed libraries
+#Externally developed libraries
+add_subdirectory(EXTERNAL)
+
+# VTR developed libraries
+#  Only add warn flags for VPR internal libraries.
+add_compile_options(${WARN_FLAGS})
 add_subdirectory(libarchfpga)
 add_subdirectory(libvtrutil)
 add_subdirectory(liblog)
 add_subdirectory(libpugiutil)
 add_subdirectory(librtlnumber)
-
-#Externally developed libraries
-add_subdirectory(EXTERNAL)
+if(${VTR_ENABLE_CAPNPROTO})
+    add_subdirectory(libvtrcapnproto)
+endif()

--- a/libs/EXTERNAL/CMakeLists.txt
+++ b/libs/EXTERNAL/CMakeLists.txt
@@ -8,8 +8,25 @@ add_subdirectory(libsdcparse)
 add_subdirectory(libblifparse)
 add_subdirectory(libtatum)
 
-#VPR_USE_EZGL is initialized in the root CMakeLists. 
+# Override default policy for capnproto and libezgl (CMake policy version 3.1)
+# Enable new IPO variables
+set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
+
+#VPR_USE_EZGL is initialized in the root CMakeLists.
 #compile libezgl only if the user asks for or has its dependencies installed.
 if(VPR_USE_EZGL STREQUAL "on")
     add_subdirectory(libezgl)
+endif()
+
+if(${VTR_ENABLE_CAPNPROTO})
+    # Enable option overrides via variables
+    set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
+    # Re-enable CXX extensions for capnproto.
+    set(CMAKE_CXX_EXTENSIONS ON)
+
+    # Disable capnproto tests
+    set(BUILD_TESTING OFF)
+
+    add_subdirectory(capnproto EXCLUDE_FROM_ALL)
 endif()

--- a/libs/libvtrcapnproto/CMakeLists.txt
+++ b/libs/libvtrcapnproto/CMakeLists.txt
@@ -1,0 +1,40 @@
+if(NOT MSCV)
+    # These flags generate noisy but non-bug warnings when using lib kj,
+    # supress them.
+    set(WARN_FLAGS_TO_DISABLE
+        -Wno-undef
+        -Wno-non-virtual-dtor
+        )
+    foreach(flag ${WARN_FLAGS_TO_DISABLE})
+        CHECK_CXX_COMPILER_FLAG(${flag} CXX_COMPILER_SUPPORTS_${flag})
+        if(CXX_COMPILER_SUPPORTS_${flag})
+            #Flag supported, so enable it
+            add_compile_options(${flag})
+        endif()
+    endforeach()
+endif()
+
+# Create generated headers from capnp schema files
+#
+# Each schema used should appear here.
+capnp_generate_cpp(CAPNP_SRCS CAPNP_HDRS
+    place_delay_model.capnp
+    connection_map.capnp
+    matrix.capnp
+    )
+
+add_library(libvtrcapnproto STATIC
+            ${CAPNP_SRCS}
+            mmap_file.h
+            mmap_file.cpp
+            serdes_utils.h
+            serdes_utils.cpp
+            )
+target_include_directories(libvtrcapnproto PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+    )
+target_link_libraries(libvtrcapnproto
+    libvtrutil
+    CapnProto::capnp
+    )

--- a/libs/libvtrcapnproto/README.md
+++ b/libs/libvtrcapnproto/README.md
@@ -1,0 +1,84 @@
+Capnproto usage in VTR
+======================
+
+Capnproto is a data serialization framework designed for portabliity and speed.
+In VPR, capnproto is used to provide binary formats for internal data
+structures that can be computed once, and used many times.  Specific examples:
+ - rrgraph
+ - Router lookahead data
+ - Place matrix delay estimates
+
+What is capnproto?
+==================
+
+capnproto can be broken down into 3 parts:
+ - A schema language
+ - A code generator
+ - A library
+
+The schema language is used to define messages.  Each message must have an
+explcit capnproto schema, which are stored in files suffixed with ".capnp".
+The capnproto documentation for how to write these schema files can be found
+here: https://capnproto.org/language.html
+
+The schema by itself is not especially useful.  In order to read and write
+messages defined by the schema in a target language (e.g. C++), a code
+generation step is required.  Capnproto provides a cmake function for this
+purpose, `capnp_generate_cpp`.  This generates C++ source and header files.
+These source and header files combined with the capnproto C++ library, enables
+C++ code to read and write the messages matching a particular schema.  The C++
+library API can be found here: https://capnproto.org/cxx.html
+
+Contents of libvtrcapnproto
+===========================
+
+libvtrcapnproto should contain two elements:
+ - Utilities for working capnproto messages in VTR
+ - Generate source and header files of all capnproto messages used in VTR
+
+I/O Utilities
+-------------
+
+Capnproto does not provide IO support, instead it works from arrays (or file
+descriptors).  To avoid re-writing this code, libvtrcapnproto provides two
+utilities that should be used whenever reading or writing capnproto message to
+disk:
+ - `serdes_utils.h` provides the writeMessageToFile function - Writes a
+   capnproto message to disk.
+ - `mmap_file.h` provides MmapFile object - Maps a capnproto message from the
+   disk as a flat array.
+
+NdMatrix Utilities
+------------------
+
+A common datatype which appears in many data structures that VPR might want to
+serialize is the generic type `vtr::NdMatrix`.  `ndmatrix_serdes.h` provides
+generic functions ToNdMatrix and FromNdMatrix, which can be used to generically
+convert between the provideid capnproto message `Matrix` and `vtr::NdMatrix`.
+
+Capnproto schemas
+-----------------
+
+libvtrcapnproto should contain all capnproto schema definitions used within
+VTR.  To add a new schema:
+1. Add the schema to git in `libs/libvtrcapnproto/`
+2. Add the schema file name to `capnp_generate_cpp` invocation in
+   `libs/libvtrcapnproto/CMakeLists.txt`.
+
+The schema will be available in the header file `schema filename>.h`.  The
+actual header file will appear in the CMake build directory
+`libs/libvtrcapnproto` after `libvtrcapnproto` has been rebuilt.
+
+Writing capnproto binary files to text
+======================================
+
+The `capnp` tool (found in the CMake build directiory
+`libs/EXTERNAL/capnproto/c++/src/capnp`) can be used to convert from a binary
+capnp message to a textual form.
+
+Example converting VprOverrideDelayModel from binary to text:
+
+```
+capnp convert binary:text place_delay_model.capnp VprOverrideDelayModel \
+  < place_delay.bin > place_delay.txt
+```

--- a/libs/libvtrcapnproto/connection_map.capnp
+++ b/libs/libvtrcapnproto/connection_map.capnp
@@ -1,0 +1,19 @@
+@0x876ec83c2fea5a18;
+
+using Matrix = import "matrix.capnp";
+
+struct VprCostEntry {
+    delay @0 :Float32;
+    congestion @1 :Float32;
+}
+
+struct VprVector2D {
+    x @0 :Int64;
+    y @1 :Int64;
+}
+
+struct VprCostMap {
+    costMap @0 :List(Matrix.Matrix(VprCostEntry));
+    offset @1 :List(VprVector2D);
+    segmentMap @2 :List(Int64);
+}

--- a/libs/libvtrcapnproto/connection_map.capnp
+++ b/libs/libvtrcapnproto/connection_map.capnp
@@ -13,7 +13,7 @@ struct VprVector2D {
 }
 
 struct VprCostMap {
-    costMap @0 :List(Matrix.Matrix(VprCostEntry));
-    offset @1 :List(VprVector2D);
+    costMap @0 :Matrix.Matrix((Matrix.Matrix(VprCostEntry)));
+    offset @1 :Matrix.Matrix(VprVector2D);
     segmentMap @2 :List(Int64);
 }

--- a/libs/libvtrcapnproto/matrix.capnp
+++ b/libs/libvtrcapnproto/matrix.capnp
@@ -1,0 +1,9 @@
+@0xafffc9c1f309bc00;
+
+struct Matrix(Value) {
+    struct Entry {
+        value @0 :Value;
+    }
+    dims @0 :List(Int64);
+    data @1 :List(Entry);
+}

--- a/libs/libvtrcapnproto/mmap_file.cpp
+++ b/libs/libvtrcapnproto/mmap_file.cpp
@@ -1,0 +1,37 @@
+#include "mmap_file.h"
+#include "vtr_error.h"
+#include "vtr_util.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "kj/filesystem.h"
+
+MmapFile::MmapFile(const std::string& file)
+    : size_(0) {
+    try {
+        auto fs = kj::newDiskFilesystem();
+        auto path = fs->getCurrentPath().evalNative(file);
+
+        const auto& dir = fs->getRoot();
+        auto stat = dir.lstat(path);
+        auto f = dir.openFile(path);
+        size_ = stat.size;
+        data_ = f->mmap(0, stat.size);
+    } catch (kj::Exception& e) {
+        throw vtr::VtrError(e.getDescription().cStr(), e.getFile(), e.getLine());
+    }
+}
+
+const kj::ArrayPtr<const ::capnp::word> MmapFile::getData() const {
+    if ((size_ % sizeof(::capnp::word)) != 0) {
+        throw vtr::VtrError(
+            vtr::string_fmt("size_ %d is not a multiple of capnp::word", size_),
+            __FILE__, __LINE__);
+    }
+
+    return kj::arrayPtr(reinterpret_cast<const ::capnp::word*>(data_.begin()),
+                        size_ / sizeof(::capnp::word));
+}

--- a/libs/libvtrcapnproto/mmap_file.h
+++ b/libs/libvtrcapnproto/mmap_file.h
@@ -1,0 +1,19 @@
+#ifndef MMAP_FILE_H_
+#define MMAP_FILE_H_
+
+#include <string>
+#include "capnp/message.h"
+#include "kj/array.h"
+
+// Platform independent mmap, useful for reading large capnp's.
+class MmapFile {
+  public:
+    explicit MmapFile(const std::string& file);
+    const kj::ArrayPtr<const ::capnp::word> getData() const;
+
+  private:
+    size_t size_;
+    kj::Array<const kj::byte> data_;
+};
+
+#endif /* MMAP_FILE_H_ */

--- a/libs/libvtrcapnproto/ndmatrix_serdes.h
+++ b/libs/libvtrcapnproto/ndmatrix_serdes.h
@@ -1,0 +1,87 @@
+#ifndef NDMATRIX_SERDES_H_
+#define NDMATRIX_SERDES_H_
+
+#include <functional>
+#include "vtr_ndmatrix.h"
+#include "vpr_error.h"
+#include "matrix.capnp.h"
+
+// Generic function to convert from Matrix capnproto message to vtr::NdMatrix.
+//
+// Template arguments:
+//  N = Number of matrix dimensions, must be fixed.
+//  CapType = Source capnproto message type that is a single element the
+//            Matrix capnproto message.
+//  CType = Target C++ type that is a single element of vtr::NdMatrix.
+//
+// Arguments:
+//  m_out = Target vtr::NdMatrix.
+//  m_in = Source capnproto message reader.
+//  copy_fun = Function to convert from CapType to CType.
+//
+template<size_t N, typename CapType, typename CType>
+void ToNdMatrix(
+    vtr::NdMatrix<CType, N>* m_out,
+    const typename Matrix<CapType>::Reader& m_in,
+    const std::function<void(CType*, const typename CapType::Reader&)>& copy_fun) {
+    const auto& dims = m_in.getDims();
+    if (N != dims.size()) {
+        VPR_THROW(VPR_ERROR_OTHER,
+                  "Wrong dimension of template N = %zu, m_in.getDims() = %zu",
+                  N, dims.size());
+    }
+
+    std::array<size_t, N> dim_sizes;
+    size_t required_elements = 1;
+    for (size_t i = 0; i < N; ++i) {
+        dim_sizes[i] = dims[i];
+        required_elements *= dims[i];
+    }
+    m_out->resize(dim_sizes);
+
+    const auto& data = m_in.getData();
+    if (data.size() != required_elements) {
+        VPR_THROW(VPR_ERROR_OTHER,
+                  "Wrong number of elements, expected %zu, actual %zu",
+                  required_elements, data.size());
+    }
+
+    for (size_t i = 0; i < required_elements; ++i) {
+        copy_fun(&m_out->get(i), data[i].getValue());
+    }
+}
+
+// Generic function to convert from vtr::NdMatrix to Matrix capnproto message.
+//
+// Template arguments:
+//  N = Number of matrix dimensions, must be fixed.
+//  CapType = Target capnproto message type that is a single element the
+//            Matrix capnproto message.
+//  CType = Source C++ type that is a single element of vtr::NdMatrix.
+//
+// Arguments:
+//  m_out = Target capnproto message builder.
+//  m_in = Source vtr::NdMatrix.
+//  copy_fun = Function to convert from CType to CapType.
+//
+template<size_t N, typename CapType, typename CType>
+void FromNdMatrix(
+    typename Matrix<CapType>::Builder* m_out,
+    const vtr::NdMatrix<CType, N>& m_in,
+    const std::function<void(typename CapType::Builder*, const CType&)>& copy_fun) {
+    size_t elements = 1;
+    auto dims = m_out->initDims(N);
+    for (size_t i = 0; i < N; ++i) {
+        dims.set(i, m_in.dim_size(i));
+        elements *= dims[i];
+    }
+
+    auto data = m_out->initData(elements);
+
+    for (size_t i = 0; i < elements; ++i) {
+        auto elem = data[i].getValue();
+        copy_fun(&elem, m_in.get(i));
+    }
+}
+
+#endif /* NDMATRIX_SERDES_H_ */

--- a/libs/libvtrcapnproto/place_delay_model.capnp
+++ b/libs/libvtrcapnproto/place_delay_model.capnp
@@ -1,0 +1,26 @@
+@0xfee98b707b92aa09;
+
+using Matrix = import "matrix.capnp";
+
+struct VprFloatEntry {
+    value @0 :Float32;
+}
+struct VprDeltaDelayModel {
+    delays @0 :Matrix.Matrix(VprFloatEntry);
+}
+
+struct VprOverrideEntry {
+    fromType @0 :Int16;
+    toType @1 :Int16;
+    fromClass @2 :Int16;
+    toClass @3 :Int16;
+    deltaX @4 :Int16;
+    deltaY @5 :Int16;
+
+    delay @6 :Float32;
+}
+
+struct VprOverrideDelayModel {
+    delays @0 :Matrix.Matrix(VprFloatEntry);
+    delayOverrides @1 :List(VprOverrideEntry);
+}

--- a/libs/libvtrcapnproto/serdes_utils.cpp
+++ b/libs/libvtrcapnproto/serdes_utils.cpp
@@ -1,0 +1,22 @@
+#include "serdes_utils.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "vtr_error.h"
+#include "kj/filesystem.h"
+
+void writeMessageToFile(const std::string& file, ::capnp::MessageBuilder* builder) {
+    try {
+        auto fs = kj::newDiskFilesystem();
+        auto path = fs->getCurrentPath().evalNative(file);
+
+        const auto& dir = fs->getRoot();
+        auto f = dir.openFile(path, kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
+        f->truncate(0);
+        auto f_app = kj::newFileAppender(std::move(f));
+        capnp::writeMessage(*f_app, *builder);
+    } catch (kj::Exception& e) {
+        throw vtr::VtrError(e.getDescription().cStr(), e.getFile(), e.getLine());
+    }
+}

--- a/libs/libvtrcapnproto/serdes_utils.h
+++ b/libs/libvtrcapnproto/serdes_utils.h
@@ -1,0 +1,11 @@
+#ifndef SERDES_UTILS_H_
+#define SERDES_UTILS_H_
+
+#include <string>
+#include "capnp/serialize.h"
+
+// Platform indepedent way to file message to a file on disk.
+void writeMessageToFile(const std::string& file,
+        ::capnp::MessageBuilder* builder);
+
+#endif /* SERDES_UTILS_H_ */

--- a/libs/libvtrutil/src/vtr_flat_map.h
+++ b/libs/libvtrutil/src/vtr_flat_map.h
@@ -85,7 +85,7 @@ class flat_map {
     }
 
     //direct vector constructor
-    explicit flat_map(std::vector<value_type>&& values) {
+    flat_map(std::vector<value_type>&& values) {
         //By moving the values this should be more efficient
         //than the range constructor which must copy each element
         vec_ = std::move(values);

--- a/utils/route_diag/src/main.cpp
+++ b/utils/route_diag/src/main.cpp
@@ -97,7 +97,8 @@ static void do_one_route(int source_node, int sink_node,
             router_opts.lookahead_type,
             router_opts.write_router_lookahead,
             router_opts.read_router_lookahead,
-            segment_inf
+            segment_inf,
+            router_opts.lookahead_search_locations
             );
     t_heap* cheapest = timing_driven_route_connection_from_route_tree(rt_root, sink_node, cost_params, bounding_box, *router_lookahead, modified_rr_node_inf, router_stats);
 
@@ -139,7 +140,8 @@ static void profile_source(int source_rr_node,
             router_opts.lookahead_type,
             router_opts.write_router_lookahead,
             router_opts.read_router_lookahead,
-            segment_inf
+            segment_inf,
+            router_opts.lookahead_search_locations
             );
     RouterDelayProfiler profiler(router_lookahead.get());
 

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -41,8 +41,13 @@ file(GLOB_RECURSE LIB_SOURCES src/*/*.cpp)
 file(GLOB_RECURSE LIB_HEADERS src/*/*.h)
 files_to_dirs(LIB_HEADERS LIB_INCLUDE_DIRS)
 
+if(${VTR_ENABLE_CAPNPROTO})
+    add_definitions("-DVTR_ENABLE_CAPNPROTO")
+endif()
+
 #Create the library
 add_library(libvpr STATIC
+             ${CAPNP_SRCS}
              ${LIB_HEADERS}
              ${LIB_SOURCES}
 )
@@ -58,7 +63,12 @@ target_link_libraries(libvpr
                         libblifparse
                         libtatum
                         libargparse
-                        libpugixml)
+                        libpugixml
+                        )
+
+if(${VTR_ENABLE_CAPNPROTO})
+    target_link_libraries(libvpr libvtrcapnproto)
+endif()
 
 #link graphics library only when graphics set to on
 if (VPR_USE_EZGL STREQUAL "on")

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -337,6 +337,7 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
         RouterOpts->doRouting = STAGE_DO;
     }
     RouterOpts->routing_failure_predictor = Options.routing_failure_predictor;
+    RouterOpts->lookahead_search_locations = Options.lookahead_search_locations;
     RouterOpts->routing_budgets_algorithm = Options.routing_budgets_algorithm;
     RouterOpts->save_routing_per_iteration = Options.save_routing_per_iteration;
     RouterOpts->congested_routing_iteration_threshold_frac = Options.congested_routing_iteration_threshold_frac;

--- a/vpr/src/base/echo_files.cpp
+++ b/vpr/src/base/echo_files.cpp
@@ -114,6 +114,8 @@ void alloc_and_load_echo_file_info() {
     setEchoFileName(E_ECHO_CHAN_DETAILS, "chan_details.txt");
     setEchoFileName(E_ECHO_SBLOCK_PATTERN, "sblock_pattern.txt");
     setEchoFileName(E_ECHO_ENDPOINT_TIMING, "endpoint_timing.echo.json");
+
+    setEchoFileName(E_ECHO_LOOKAHEAD_MAP, "lookahead_map.echo");
 }
 
 void free_echo_file_info() {

--- a/vpr/src/base/echo_files.h
+++ b/vpr/src/base/echo_files.h
@@ -46,6 +46,7 @@ enum e_echo_files {
     E_ECHO_CHAN_DETAILS,
     E_ECHO_SBLOCK_PATTERN,
     E_ECHO_ENDPOINT_TIMING,
+    E_ECHO_LOOKAHEAD_MAP,
 
     //Timing Graphs
     E_ECHO_PRE_PACKING_TIMING_GRAPH,

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -648,6 +648,8 @@ struct ParseRouterLookahead {
             conv_value.set_value(e_router_lookahead::CLASSIC);
         else if (str == "map")
             conv_value.set_value(e_router_lookahead::MAP);
+        else if (str == "connection_box_map")
+            conv_value.set_value(e_router_lookahead::CONNECTION_BOX_MAP);
         else {
             std::stringstream msg;
             msg << "Invalid conversion from '"
@@ -661,17 +663,22 @@ struct ParseRouterLookahead {
 
     ConvertedValue<std::string> to_str(e_router_lookahead val) {
         ConvertedValue<std::string> conv_value;
-        if (val == e_router_lookahead::CLASSIC)
+        if (val == e_router_lookahead::CLASSIC) {
             conv_value.set_value("classic");
-        else {
-            VTR_ASSERT(val == e_router_lookahead::MAP);
+        } else if (val == e_router_lookahead::MAP) {
             conv_value.set_value("map");
+        } else if (val == e_router_lookahead::CONNECTION_BOX_MAP) {
+            conv_value.set_value("connection_box_map");
+        } else {
+            std::stringstream msg;
+            msg << "Unrecognized e_router_lookahead";
+            conv_value.set_error(msg.str());
         }
         return conv_value;
     }
 
     std::vector<std::string> default_choices() {
-        return {"classic", "map"};
+        return {"classic", "map", "connection_box_map"};
     }
 };
 

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1497,6 +1497,11 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("1.2")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    route_timing_grp.add_argument(args.lookahead_search_locations, "--lookahead_search_locations")
+        .help("Semi-colon seperated x,y coordinates to use for lookahead search coordinates.")
+        .default_value("")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     route_timing_grp.add_argument(args.max_criticality, "--max_criticality")
         .help(
             "Sets the maximum fraction of routing cost derived from delay (vs routability) for any net."

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -150,6 +150,7 @@ struct t_options {
     argparse::ArgValue<int> router_max_convergence_count;
     argparse::ArgValue<float> router_reconvergence_cpd_threshold;
     argparse::ArgValue<std::string> router_first_iteration_timing_report_file;
+    argparse::ArgValue<std::string> lookahead_search_locations;
 
     /* Analysis options */
     argparse::ArgValue<bool> full_stats;

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -724,7 +724,8 @@ RouteStatus vpr_route_fixed_W(t_vpr_setup& vpr_setup,
             vpr_setup.RouterOpts.lookahead_type,
             vpr_setup.RouterOpts.write_router_lookahead,
             vpr_setup.RouterOpts.read_router_lookahead,
-            vpr_setup.Segments);
+            vpr_setup.Segments,
+            vpr_setup.RouterOpts.lookahead_search_locations);
     }
 
     vtr::ScopedStartFinishTimer timer("Routing");

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -22,6 +22,7 @@
 #include "router_lookahead.h"
 #include "place_macro.h"
 #include "compressed_grid.h"
+#include "connection_box.h"
 
 //A Context is collection of state relating to a particular part of VPR
 //
@@ -200,6 +201,8 @@ struct DeviceContext : public Context {
     // Name of rrgraph file read (if any).
     // Used to determine when reading rrgraph if file is already loaded.
     std::string read_rr_graph_filename;
+
+    ConnectionBoxes connection_boxes;
 };
 
 //State relating to power analysis

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -289,7 +289,7 @@ struct RoutingContext : public Context {
     // Cache of router lookahead object.
     //
     // Cache key: (lookahead type, read lookahead (if any), segment definitions).
-    vtr::Cache<std::tuple<e_router_lookahead, std::string, std::vector<t_segment_inf>>,
+    vtr::Cache<std::tuple<e_router_lookahead, std::string, std::vector<t_segment_inf>, std::string>,
                RouterLookahead>
         cached_router_lookahead_;
 };

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -104,7 +104,10 @@ constexpr const char* EMPTY_BLOCK_NAME = "EMPTY";
 enum class e_router_lookahead {
     CLASSIC, //VPR's classic lookahead (assumes uniform wire types)
     MAP,     //Lookahead considering different wire types (see Oleg Petelin's MASc Thesis)
-    NO_OP    //A no-operation lookahead which always returns zero
+    NO_OP,   //A no-operation lookahead which always returns zero
+    CONNECTION_BOX_MAP,
+    // Lookahead considering different wire types and IPIN
+    // connection box.
 };
 
 enum class e_route_bb_update {

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -942,6 +942,7 @@ struct t_router_opts {
     float reconvergence_cpd_threshold;
     std::string first_iteration_timing_report_file;
     bool strict_checks;
+    std::string lookahead_search_locations;
 
     std::string write_router_lookahead;
     std::string read_router_lookahead;

--- a/vpr/src/place/place_delay_model.cpp
+++ b/vpr/src/place/place_delay_model.cpp
@@ -8,6 +8,15 @@
 
 #include "vtr_log.h"
 #include "vtr_math.h"
+#include "vpr_error.h"
+
+#ifdef VTR_ENABLE_CAPNPROTO
+#    include "capnp/serialize.h"
+#    include "place_delay_model.capnp.h"
+#    include "ndmatrix_serdes.h"
+#    include "mmap_file.h"
+#    include "serdes_utils.h"
+#endif /* VTR_ENABLE_CAPNPROTO */
 
 /*
  * DeltaDelayModel
@@ -110,3 +119,178 @@ void OverrideDelayModel::dump_echo(std::string filepath) const {
 
     vtr::fclose(f);
 }
+
+float OverrideDelayModel::get_delay_override(int from_type, int from_class, int to_type, int to_class, int delta_x, int delta_y) const {
+    t_override key;
+    key.from_type = from_type;
+    key.from_class = from_class;
+    key.to_type = to_type;
+    key.to_class = to_class;
+    key.delta_x = delta_x;
+    key.delta_y = delta_y;
+
+    auto iter = delay_overrides_.find(key);
+    if (iter == delay_overrides_.end()) {
+        VPR_THROW(VPR_ERROR_PLACE, "Key not found.");
+    }
+    return iter->second;
+}
+
+const DeltaDelayModel* OverrideDelayModel::base_delay_model() const {
+    return base_delay_model_.get();
+}
+
+void OverrideDelayModel::set_base_delay_model(std::unique_ptr<DeltaDelayModel> base_delay_model) {
+    base_delay_model_ = std::move(base_delay_model);
+}
+
+// When writing capnp targetted serialization, always allow compilation when
+// VTR_ENABLE_CAPNPROTO=OFF.  Generally this means throwing an exception
+// instead.
+//
+#ifndef VTR_ENABLE_CAPNPROTO
+
+#    define DISABLE_ERROR                              \
+        "is disable because VTR_ENABLE_CAPNPROTO=OFF." \
+        "Re-compile with CMake option VTR_ENABLE_CAPNPROTO=ON to enable."
+
+void DeltaDelayModel::read(const std::string& /*file*/) {
+    VPR_THROW(VPR_ERROR_PLACE, "DeltaDelayModel::read " DISABLE_ERROR);
+}
+
+void DeltaDelayModel::write(const std::string& /*file*/) const {
+    VPR_THROW(VPR_ERROR_PLACE, "DeltaDelayModel::write " DISABLE_ERROR);
+}
+
+void OverrideDelayModel::read(const std::string& /*file*/) {
+    VPR_THROW(VPR_ERROR_PLACE, "OverrideDelayModel::read " DISABLE_ERROR);
+}
+
+void OverrideDelayModel::write(const std::string& /*file*/) const {
+    VPR_THROW(VPR_ERROR_PLACE, "OverrideDelayModel::write " DISABLE_ERROR);
+}
+
+#else /* VTR_ENABLE_CAPNPROTO */
+
+static void ToFloat(float* out, const VprFloatEntry::Reader& in) {
+    // Getting a scalar field is always "get<field name>()".
+    *out = in.getValue();
+}
+
+static void FromFloat(VprFloatEntry::Builder* out, const float& in) {
+    // Setting a scalar field is always "set<field name>(value)".
+    out->setValue(in);
+}
+
+void DeltaDelayModel::read(const std::string& file) {
+    // MmapFile object creates an mmap of the specified path, and will munmap
+    // when the object leaves scope.
+    MmapFile f(file);
+
+    // FlatArrayMessageReader is used to read the message from the data array
+    // provided by MmapFile.
+    ::capnp::FlatArrayMessageReader reader(f.getData());
+
+    // When reading capnproto files the Reader object to use is named
+    // <schema name>::Reader.
+    //
+    // Initially this object is an empty VprDeltaDelayModel.
+    VprDeltaDelayModel::Reader model;
+
+    // The reader.getRoot performs a cast from the generic capnproto to fit
+    // with the specified schema.
+    //
+    // Note that capnproto does not validate that the incoming data matches the
+    // schema.  If this property is required, some form of check would be
+    // required.
+    model = reader.getRoot<VprDeltaDelayModel>();
+
+    // ToNdMatrix is a generic function for converting a Matrix capnproto
+    // to a vtr::NdMatrix.
+    //
+    // The use must supply the matrix dimension (2 in this case), the source
+    // capnproto type (VprFloatEntry),
+    // target C++ type (flat), and a function to convert from the source capnproto
+    // type to the target C++ type (ToFloat).
+    //
+    // The second argument should be of type Matrix<X>::Reader where X is the
+    // capnproto element type.
+    ToNdMatrix<2, VprFloatEntry, float>(&delays_, model.getDelays(), ToFloat);
+}
+
+void DeltaDelayModel::write(const std::string& file) const {
+    // MallocMessageBuilder object is the generate capnproto message builder,
+    // using malloc for buffer allocation.
+    ::capnp::MallocMessageBuilder builder;
+
+    // initRoot<X> returns a X::Builder object that can be used to set the
+    // fields in the message.
+    auto model = builder.initRoot<VprDeltaDelayModel>();
+
+    // FromNdMatrix is a generic function for converting a vtr::NdMatrix to a
+    // Matrix message.  It is the mirror function of ToNdMatrix described in
+    // read above.
+    auto delays = model.getDelays();
+    FromNdMatrix<2, VprFloatEntry, float>(&delays, delays_, FromFloat);
+
+    // writeMessageToFile writes message to the specified file.
+    writeMessageToFile(file, &builder);
+}
+
+void OverrideDelayModel::read(const std::string& file) {
+    MmapFile f(file);
+    ::capnp::FlatArrayMessageReader reader(f.getData());
+
+    vtr::Matrix<float> delays;
+    auto model = reader.getRoot<VprOverrideDelayModel>();
+    ToNdMatrix<2, VprFloatEntry, float>(&delays, model.getDelays(), ToFloat);
+
+    base_delay_model_ = std::make_unique<DeltaDelayModel>(delays);
+
+    // Reading non-scalar capnproto fields is roughly equivilant to using
+    // a std::vector of the field type.  Actual type is capnp::List<X>::Reader.
+    auto overrides = model.getDelayOverrides();
+    std::vector<std::pair<t_override, float> > overrides_arr(overrides.size());
+    for (size_t i = 0; i < overrides.size(); ++i) {
+        const auto& elem = overrides[i];
+        overrides_arr[i].first.from_type = elem.getFromType();
+        overrides_arr[i].first.to_type = elem.getToType();
+        overrides_arr[i].first.from_class = elem.getFromClass();
+        overrides_arr[i].first.to_class = elem.getToClass();
+        overrides_arr[i].first.delta_x = elem.getDeltaX();
+        overrides_arr[i].first.delta_y = elem.getDeltaY();
+
+        overrides_arr[i].second = elem.getDelay();
+    }
+
+    delay_overrides_ = vtr::make_flat_map2(std::move(overrides_arr));
+}
+
+void OverrideDelayModel::write(const std::string& file) const {
+    ::capnp::MallocMessageBuilder builder;
+    auto model = builder.initRoot<VprOverrideDelayModel>();
+
+    auto delays = model.getDelays();
+    FromNdMatrix<2, VprFloatEntry, float>(&delays, base_delay_model_->delays(), FromFloat);
+
+    // Non-scalar capnproto fields should be first initialized with
+    // init<field  name>(count), and then accessed from the returned
+    // std::vector-like Builder object (specifically capnp::List<X>::Builder).
+    auto overrides = model.initDelayOverrides(delay_overrides_.size());
+    auto dst_iter = overrides.begin();
+    for (const auto& src : delay_overrides_) {
+        auto elem = *dst_iter++;
+        elem.setFromType(src.first.from_type);
+        elem.setToType(src.first.to_type);
+        elem.setFromClass(src.first.from_class);
+        elem.setToClass(src.first.to_class);
+        elem.setDeltaX(src.first.delta_x);
+        elem.setDeltaY(src.first.delta_y);
+
+        elem.setDelay(src.second);
+    }
+
+    writeMessageToFile(file, &builder);
+}
+
+#endif

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -182,7 +182,6 @@ void DeltaDelayModel::compute(
     const t_placer_opts& placer_opts,
     const t_router_opts& router_opts,
     int longest_length) {
-    router_opts_ = router_opts;
     delays_ = compute_delta_delay_model(
         route_profiler,
         placer_opts, router_opts, /*measure_directconnect=*/true,
@@ -194,15 +193,14 @@ void OverrideDelayModel::compute(
     const t_placer_opts& placer_opts,
     const t_router_opts& router_opts,
     int longest_length) {
-    router_opts_ = router_opts;
     auto delays = compute_delta_delay_model(
         route_profiler,
         placer_opts, router_opts, /*measure_directconnect=*/false,
         longest_length);
 
-    base_delay_model_ = std::make_unique<DeltaDelayModel>(delays, router_opts);
+    base_delay_model_ = std::make_unique<DeltaDelayModel>(delays);
 
-    compute_override_delay_model(route_profiler);
+    compute_override_delay_model(route_profiler, router_opts);
 }
 
 /******* File Accessible Functions **********/
@@ -837,8 +835,10 @@ static bool verify_delta_delays(const vtr::Matrix<float>& delta_delays) {
     return true;
 }
 
-void OverrideDelayModel::compute_override_delay_model(const RouterDelayProfiler& route_profiler) {
-    t_router_opts router_opts2 = router_opts_;
+void OverrideDelayModel::compute_override_delay_model(
+    const RouterDelayProfiler& route_profiler,
+    const t_router_opts& router_opts) {
+    t_router_opts router_opts2 = router_opts;
     router_opts2.astar_fac = 0.;
 
     //Look at all the direct connections that exist, and add overrides to delay model

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -146,7 +146,8 @@ std::unique_ptr<PlaceDelayModel> compute_place_delay_model(const t_placer_opts& 
         router_opts.lookahead_type,
         router_opts.write_router_lookahead,
         router_opts.read_router_lookahead,
-        segment_inf);
+        segment_inf,
+        router_opts.lookahead_search_locations);
     RouterDelayProfiler route_profiler(router_lookahead);
 
     int longest_length = get_longest_segment_length(segment_inf);

--- a/vpr/src/route/connection_box.cpp
+++ b/vpr/src/route/connection_box.cpp
@@ -1,0 +1,127 @@
+#include "connection_box.h"
+#include "vtr_assert.h"
+#include "globals.h"
+
+ConnectionBoxes::ConnectionBoxes()
+    : size_(std::make_pair(0, 0)) {
+}
+
+size_t ConnectionBoxes::num_connection_box_types() const {
+    return boxes_.size();
+}
+
+std::pair<size_t, size_t> ConnectionBoxes::connection_box_grid_size() const {
+    return size_;
+}
+
+const ConnectionBox* ConnectionBoxes::get_connection_box(ConnectionBoxId box) const {
+    if (bool(box)) {
+        return nullptr;
+    }
+
+    size_t index = size_t(box);
+    if (index >= boxes_.size()) {
+        return nullptr;
+    }
+
+    return &boxes_.at(index);
+}
+
+bool ConnectionBoxes::find_connection_box(int inode,
+                                          ConnectionBoxId* box_id,
+                                          std::pair<size_t, size_t>* box_location) const {
+    VTR_ASSERT(box_id != nullptr);
+    VTR_ASSERT(box_location != nullptr);
+
+    const auto& conn_box_loc = ipin_map_[inode];
+    if (conn_box_loc.box_id == ConnectionBoxId::INVALID()) {
+        return false;
+    }
+
+    *box_id = conn_box_loc.box_id;
+    *box_location = conn_box_loc.box_location;
+    return true;
+}
+
+// Clear IPIN map and set connection box grid size and box ids.
+void ConnectionBoxes::reset_boxes(std::pair<size_t, size_t> size,
+                                  const std::vector<ConnectionBox> boxes) {
+    clear();
+
+    size_ = size;
+    boxes_ = boxes;
+}
+
+void ConnectionBoxes::resize_nodes(size_t rr_node_size) {
+    ipin_map_.resize(rr_node_size);
+    canonical_loc_map_.resize(rr_node_size,
+                              std::make_pair(-1, -1));
+}
+
+void ConnectionBoxes::clear() {
+    ipin_map_.clear();
+    size_ = std::make_pair(0, 0);
+    boxes_.clear();
+    canonical_loc_map_.clear();
+    sink_to_ipin_.clear();
+}
+
+void ConnectionBoxes::add_connection_box(int inode, ConnectionBoxId box_id, std::pair<size_t, size_t> box_location) {
+    // Ensure that box location is in bounds
+    VTR_ASSERT(box_location.first < size_.first);
+    VTR_ASSERT(box_location.second < size_.second);
+
+    // Bounds check box_id
+    VTR_ASSERT(bool(box_id));
+    VTR_ASSERT(size_t(box_id) < boxes_.size());
+
+    // Make sure sink map will not be invalidated upon insertion.
+    VTR_ASSERT(sink_to_ipin_.size() == 0);
+
+    ipin_map_[inode] = ConnBoxLoc(box_location, box_id);
+}
+
+void ConnectionBoxes::add_canonical_loc(int inode, std::pair<size_t, size_t> loc) {
+    VTR_ASSERT(loc.first < size_.first);
+    VTR_ASSERT(loc.second < size_.second);
+    canonical_loc_map_[inode] = loc;
+}
+
+const std::pair<size_t, size_t>* ConnectionBoxes::find_canonical_loc(int inode) const {
+    const auto& canon_loc = canonical_loc_map_[inode];
+    if (canon_loc.first == size_t(-1)) {
+        return nullptr;
+    }
+
+    return &canon_loc;
+}
+
+void ConnectionBoxes::create_sink_back_ref() {
+    const auto& device_ctx = g_vpr_ctx.device();
+
+    sink_to_ipin_.resize(device_ctx.rr_nodes.size(), {{0, 0, 0, 0}, 0});
+
+    for (size_t i = 0; i < device_ctx.rr_nodes.size(); ++i) {
+        const auto& ipin_node = device_ctx.rr_nodes[i];
+        if (ipin_node.type() != IPIN) {
+            continue;
+        }
+
+        if (ipin_map_[i].box_id == ConnectionBoxId::INVALID()) {
+            continue;
+        }
+
+        for (auto edge : ipin_node.edges()) {
+            int sink_inode = ipin_node.edge_sink_node(edge);
+            VTR_ASSERT(device_ctx.rr_nodes[sink_inode].type() == SINK);
+            VTR_ASSERT(sink_to_ipin_[sink_inode].ipin_count < 4);
+            auto& sink_to_ipin = sink_to_ipin_[sink_inode];
+            sink_to_ipin.ipin_nodes[sink_to_ipin.ipin_count++] = i;
+        }
+    }
+}
+
+const SinkToIpin& ConnectionBoxes::find_sink_connection_boxes(
+    int inode) const {
+    return sink_to_ipin_[inode];
+}

--- a/vpr/src/route/connection_box.h
+++ b/vpr/src/route/connection_box.h
@@ -1,0 +1,76 @@
+#ifndef CONNECTION_BOX_H
+#define CONNECTION_BOX_H
+// Some routing graphs have connectivity driven by types of connection boxes.
+// This class relates IPIN rr nodes with connection box type and locations, used
+// for connection box driven map lookahead.
+
+#include <tuple>
+#include "vtr_strong_id.h"
+#include "vtr_flat_map.h"
+#include "vtr_range.h"
+#include <map>
+
+struct connection_box_tag {};
+typedef vtr::StrongId<connection_box_tag> ConnectionBoxId;
+
+struct ConnectionBox {
+    std::string name;
+};
+
+struct ConnBoxLoc {
+    ConnBoxLoc()
+        : box_location(std::make_pair(-1, -1)) {}
+    ConnBoxLoc(
+        const std::pair<size_t, size_t>& a_box_location,
+        ConnectionBoxId a_box_id)
+        : box_location(a_box_location)
+        , box_id(a_box_id) {}
+
+    std::pair<size_t, size_t> box_location;
+    ConnectionBoxId box_id;
+};
+
+struct SinkToIpin {
+    int ipin_nodes[4];
+    int ipin_count;
+};
+
+class ConnectionBoxes {
+  public:
+    ConnectionBoxes();
+
+    size_t num_connection_box_types() const;
+    std::pair<size_t, size_t> connection_box_grid_size() const;
+    const ConnectionBox* get_connection_box(ConnectionBoxId box) const;
+
+    bool find_connection_box(int inode,
+                             ConnectionBoxId* box_id,
+                             std::pair<size_t, size_t>* box_location) const;
+    const std::pair<size_t, size_t>* find_canonical_loc(int inode) const;
+
+    // Clear IPIN map and set connection box grid size and box ids.
+    void clear();
+    void reset_boxes(std::pair<size_t, size_t> size,
+                     const std::vector<ConnectionBox> boxes);
+    void resize_nodes(size_t rr_node_size);
+
+    void add_connection_box(int inode, ConnectionBoxId box_id, std::pair<size_t, size_t> box_location);
+    void add_canonical_loc(int inode, std::pair<size_t, size_t> loc);
+
+    // Create map from SINK's back to IPIN's
+    //
+    // This must be called after all connection boxes have been added.
+    void create_sink_back_ref();
+    const SinkToIpin& find_sink_connection_boxes(
+        int inode) const;
+
+  private:
+    std::pair<size_t, size_t> size_;
+    std::vector<ConnectionBox> boxes_;
+    std::vector<ConnBoxLoc> ipin_map_;
+    std::vector<SinkToIpin> sink_to_ipin_;
+    std::vector<std::pair<size_t, size_t>>
+        canonical_loc_map_;
+};
+
+#endif

--- a/vpr/src/route/connection_box_lookahead_map.cpp
+++ b/vpr/src/route/connection_box_lookahead_map.cpp
@@ -1,0 +1,578 @@
+#include "connection_box_lookahead_map.h"
+
+#include <vector>
+#include <queue>
+
+#include "connection_box.h"
+#include "rr_node.h"
+#include "router_lookahead_map_utils.h"
+#include "globals.h"
+#include "vtr_math.h"
+#include "vtr_time.h"
+#include "echo_files.h"
+
+#include "route_timing.h"
+
+#include "capnp/serialize.h"
+#include "connection_map.capnp.h"
+#include "ndmatrix_serdes.h"
+#include "mmap_file.h"
+#include "serdes_utils.h"
+
+/* we're profiling routing cost over many tracks for each wire type, so we'll
+ * have many cost entries at each |dx|,|dy| offset. There are many ways to
+ * "boil down" the many costs at each offset to a single entry for a given
+ * (wire type, chan_type) combination we can take the smallest cost, the
+ * average, median, etc. This define selects the method we use.
+ *
+ * See e_representative_entry_method */
+#define REPRESENTATIVE_ENTRY_METHOD SMALLEST
+
+#define REF_X 25
+#define REF_Y 23
+
+static int signum(int x) {
+    if (x > 0) return 1;
+    if (x < 0)
+        return -1;
+    else
+        return 0;
+}
+
+typedef std::vector<std::pair<std::pair<int, int>, Cost_Entry>> t_routing_cost_map;
+static void run_dijkstra(int start_node_ind,
+                         t_routing_cost_map* cost_map);
+
+class CostMap {
+  public:
+    void set_segment_count(size_t seg_count) {
+        cost_map_.clear();
+        offset_.clear();
+        cost_map_.resize(seg_count);
+        offset_.resize(seg_count);
+
+        const auto& device_ctx = g_vpr_ctx.device();
+        segment_map_.resize(device_ctx.rr_nodes.size());
+        for (size_t i = 0; i < segment_map_.size(); ++i) {
+            auto& from_node = device_ctx.rr_nodes[i];
+
+            int from_cost_index = from_node.cost_index();
+            int from_seg_index = device_ctx.rr_indexed_data[from_cost_index].seg_index;
+
+            segment_map_[i] = from_seg_index;
+        }
+    }
+
+    int node_to_segment(int from_node_ind) {
+        return segment_map_[from_node_ind];
+    }
+
+    Cost_Entry find_cost(int from_seg_index, int delta_x, int delta_y) const {
+        VTR_ASSERT(from_seg_index >= 0 && from_seg_index < (ssize_t)offset_.size());
+        int dx = delta_x - offset_[from_seg_index].first;
+        int dy = delta_y - offset_[from_seg_index].second;
+        const auto& cost_map = cost_map_[from_seg_index];
+
+        if (dx < 0) {
+            dx = 0;
+        }
+        if (dy < 0) {
+            dy = 0;
+        }
+
+        if (dx >= (ssize_t)cost_map.dim_size(0)) {
+            dx = cost_map.dim_size(0) - 1;
+        }
+        if (dy >= (ssize_t)cost_map.dim_size(1)) {
+            dy = cost_map.dim_size(1) - 1;
+        }
+
+        return cost_map_[from_seg_index][dx][dy];
+    }
+
+    void set_cost_map(int from_seg_index,
+                      const t_routing_cost_map& cost_map,
+                      e_representative_entry_method method) {
+        VTR_ASSERT(from_seg_index >= 0 && from_seg_index < (ssize_t)offset_.size());
+
+        // Find coordinate offset for this segment.
+        int min_dx = 0;
+        int min_dy = 0;
+        int max_dx = 0;
+        int max_dy = 0;
+        for (const auto& entry : cost_map) {
+            min_dx = std::min(entry.first.first, min_dx);
+            min_dy = std::min(entry.first.second, min_dy);
+
+            max_dx = std::max(entry.first.first, max_dx);
+            max_dy = std::max(entry.first.second, max_dy);
+        }
+
+        offset_[from_seg_index].first = min_dx;
+        offset_[from_seg_index].second = min_dy;
+        size_t dim_x = max_dx - min_dx + 1;
+        size_t dim_y = max_dy - min_dy + 1;
+
+        vtr::NdMatrix<Expansion_Cost_Entry, 2> expansion_cost_map(
+            {dim_x, dim_y});
+
+        for (const auto& entry : cost_map) {
+            int x = entry.first.first - min_dx;
+            int y = entry.first.second - min_dy;
+            expansion_cost_map[x][y].add_cost_entry(
+                method, entry.second.delay,
+                entry.second.congestion);
+        }
+
+        cost_map_[from_seg_index] = vtr::NdMatrix<Cost_Entry, 2>(
+            {dim_x, dim_y});
+
+        /* set the lookahead cost map entries with a representative cost
+         * entry from routing_cost_map */
+        for (unsigned ix = 0; ix < expansion_cost_map.dim_size(0); ix++) {
+            for (unsigned iy = 0; iy < expansion_cost_map.dim_size(1); iy++) {
+                cost_map_[from_seg_index][ix][iy] = expansion_cost_map[ix][iy].get_representative_cost_entry(method);
+            }
+        }
+
+        /* find missing cost entries and fill them in by copying a nearby cost entry */
+        for (unsigned ix = 0; ix < expansion_cost_map.dim_size(0); ix++) {
+            for (unsigned iy = 0; iy < expansion_cost_map.dim_size(1); iy++) {
+                Cost_Entry cost_entry = cost_map_[from_seg_index][ix][iy];
+
+                if (!cost_entry.valid()) {
+                    Cost_Entry copied_entry = get_nearby_cost_entry(
+                        from_seg_index,
+                        offset_[from_seg_index].first + ix,
+                        offset_[from_seg_index].second + iy);
+                    cost_map_[from_seg_index][ix][iy] = copied_entry;
+                }
+            }
+        }
+    }
+
+    Cost_Entry get_nearby_cost_entry(int segment_index, int x, int y) {
+        /* compute the slope from x,y to 0,0 and then move towards 0,0 by one
+         * unit to get the coordinates of the cost entry to be copied */
+
+        float slope;
+        int copy_x, copy_y;
+        if (x == 0 || y == 0) {
+            slope = std::numeric_limits<float>::infinity();
+            copy_x = x - signum(x);
+            copy_y = y - signum(y);
+        } else {
+            slope = (float)y / (float)x;
+            if (slope >= 1.0) {
+                copy_y = y - signum(y);
+                copy_x = vtr::nint((float)y / slope);
+            } else {
+                copy_x = x - signum(x);
+                copy_y = vtr::nint((float)x * slope);
+            }
+        }
+
+        Cost_Entry copy_entry = find_cost(segment_index, copy_x, copy_y);
+
+        /* if the entry to be copied is also empty, recurse */
+        if (copy_entry.valid()) {
+            return copy_entry;
+        } else if (copy_x == 0 && copy_y == 0) {
+            return Cost_Entry();
+        }
+
+        return get_nearby_cost_entry(segment_index, copy_x, copy_y);
+    }
+
+    void print_cost_map(const std::vector<t_segment_inf>& segment_inf,
+                        const char* fname) {
+        FILE* fp = vtr::fopen(fname, "w");
+        for (size_t iseg = 0; iseg < cost_map_.size(); iseg++) {
+            fprintf(fp, "Seg %s(%zu) (%d, %d)\n", segment_inf.at(iseg).name.c_str(),
+                    iseg,
+                    offset_[iseg].first,
+                    offset_[iseg].second);
+            for (size_t iy = 0; iy < cost_map_[iseg].dim_size(1); iy++) {
+                for (size_t ix = 0; ix < cost_map_[iseg].dim_size(0); ix++) {
+                    fprintf(fp, "%.4g,\t",
+                            cost_map_[iseg][ix][iy].delay);
+                }
+                fprintf(fp, "\n");
+            }
+            fprintf(fp, "\n\n");
+        }
+
+        fclose(fp);
+    }
+
+    void read(const std::string& file);
+    void write(const std::string& file) const;
+
+  private:
+    std::vector<vtr::NdMatrix<Cost_Entry, 2>> cost_map_;
+    std::vector<std::pair<int, int>> offset_;
+    std::vector<int> segment_map_;
+};
+
+static CostMap g_cost_map;
+
+class StartNode {
+  public:
+    StartNode(int start_x, int start_y, t_rr_type rr_type, int seg_index)
+        : start_x_(start_x)
+        , start_y_(start_y)
+        , rr_type_(rr_type)
+        , seg_index_(seg_index)
+        , index_(0) {}
+    int get_next_node() {
+        const auto& device_ctx = g_vpr_ctx.device();
+        const std::vector<int>& channel_node_list = device_ctx.rr_node_indices[rr_type_][start_x_][start_y_][0];
+
+        for (; index_ < channel_node_list.size(); index_++) {
+            int node_ind = channel_node_list[index_];
+
+            if (node_ind == OPEN || device_ctx.rr_nodes[node_ind].capacity() == 0) {
+                continue;
+            }
+
+            const std::pair<size_t, size_t>* loc = device_ctx.connection_boxes.find_canonical_loc(node_ind);
+            if (loc == nullptr) {
+                continue;
+            }
+
+            int node_cost_ind = device_ctx.rr_nodes[node_ind].cost_index();
+            int node_seg_ind = device_ctx.rr_indexed_data[node_cost_ind].seg_index;
+            if (node_seg_ind == seg_index_) {
+                index_ += 1;
+                return node_ind;
+            }
+        }
+
+        return UNDEFINED;
+    }
+
+  private:
+    int start_x_;
+    int start_y_;
+    t_rr_type rr_type_;
+    int seg_index_;
+    size_t index_;
+};
+
+// Minimum size of search for channels to profile.  kMinProfile results
+// in searching x = [0, kMinProfile], and y = [0, kMinProfile[.
+//
+// Making this value larger will increase the sample size, but also the runtime
+// to produce the lookahead.
+static constexpr int kMinProfile = 1;
+
+// Maximum size of search for channels to profile.  Once search is outside of
+// kMinProfile distance, lookahead will stop searching once:
+//  - At least one channel has been profiled
+//  - kMaxProfile is exceeded.
+static constexpr int kMaxProfile = 7;
+
+static void compute_connection_box_lookahead(
+    const std::vector<t_segment_inf>& segment_inf) {
+    size_t num_segments = segment_inf.size();
+    vtr::ScopedStartFinishTimer timer("Computing connection box lookahead map");
+
+    /* free previous delay map and allocate new one */
+    g_cost_map.set_segment_count(segment_inf.size());
+
+    /* run Dijkstra's algorithm for each segment type & channel type combination */
+    for (int iseg = 0; iseg < (ssize_t)num_segments; iseg++) {
+        VTR_LOG("Creating cost map for %s(%d)\n",
+                segment_inf[iseg].name.c_str(), iseg);
+        /* allocate the cost map for this iseg/chan_type */
+        t_routing_cost_map cost_map;
+
+        int count = 0;
+
+        int dx = 0;
+        int dy = 0;
+        //int start_x = vtr::nint(device_ctx.grid.width()/2);
+        //int start_y = vtr::nint(device_ctx.grid.height()/2);
+        int start_x = REF_X;
+        int start_y = REF_Y;
+        while ((count == 0 && dx < kMaxProfile) || dy <= kMinProfile) {
+            for (e_rr_type chan_type : {CHANX, CHANY}) {
+                StartNode start_node(start_x + dx, start_y + dy, chan_type, iseg);
+
+                for (int start_node_ind = start_node.get_next_node();
+                     start_node_ind != UNDEFINED;
+                     start_node_ind = start_node.get_next_node()) {
+                    count += 1;
+
+                    /* run Dijkstra's algorithm */
+                    run_dijkstra(start_node_ind, &cost_map);
+                }
+            }
+
+            if (dy < dx) {
+                dy += 1;
+            } else {
+                dx += 1;
+            }
+        }
+
+        if (count == 0) {
+            VTR_LOG_WARN("Segment %s(%d) found no start_node_ind\n",
+                         segment_inf[iseg].name.c_str(), iseg);
+        }
+
+        /* boil down the cost list in routing_cost_map at each coordinate to a
+         * representative cost entry and store it in the lookahead cost map */
+        g_cost_map.set_cost_map(iseg, cost_map,
+                                REPRESENTATIVE_ENTRY_METHOD);
+    }
+
+    if (getEchoEnabled() && isEchoFileEnabled(E_ECHO_LOOKAHEAD_MAP)) {
+        g_cost_map.print_cost_map(segment_inf, getEchoFileName(E_ECHO_LOOKAHEAD_MAP));
+    }
+}
+
+static float get_connection_box_lookahead_map_cost(int from_node_ind,
+                                                   int to_node_ind,
+                                                   float criticality_fac) {
+    if (from_node_ind == to_node_ind) {
+        return 0.f;
+    }
+
+    auto& device_ctx = g_vpr_ctx.device();
+
+    std::pair<size_t, size_t> from_location;
+    std::pair<size_t, size_t> to_location;
+    auto to_node_type = device_ctx.rr_nodes[to_node_ind].type();
+
+    if (to_node_type == SINK) {
+        const auto& sink_to_ipin = device_ctx.connection_boxes.find_sink_connection_boxes(to_node_ind);
+        if (sink_to_ipin.ipin_count > 1) {
+            float cost = std::numeric_limits<float>::infinity();
+            // Find cheapest cost from from_node_ind to IPINs for this SINK.
+            for (int i = 0; i < sink_to_ipin.ipin_count; ++i) {
+                cost = std::min(cost,
+                                get_connection_box_lookahead_map_cost(
+                                    from_node_ind,
+                                    sink_to_ipin.ipin_nodes[i], criticality_fac));
+            }
+
+            return cost;
+        } else if (sink_to_ipin.ipin_count == 1) {
+            to_node_ind = sink_to_ipin.ipin_nodes[0];
+            if (from_node_ind == to_node_ind) {
+                return 0.f;
+            }
+        } else {
+            return std::numeric_limits<float>::infinity();
+        }
+    }
+
+    if (device_ctx.rr_nodes[to_node_ind].type() == IPIN) {
+        ConnectionBoxId box_id;
+        std::pair<size_t, size_t> box_location;
+        bool found = device_ctx.connection_boxes.find_connection_box(
+            to_node_ind, &box_id, &box_location);
+        if (!found) {
+            VPR_THROW(VPR_ERROR_ROUTE, "No connection box for IPIN %d", to_node_ind);
+        }
+
+        to_location = box_location;
+    } else {
+        const std::pair<size_t, size_t>* to_canonical_loc = device_ctx.connection_boxes.find_canonical_loc(to_node_ind);
+        if (!to_canonical_loc) {
+            VPR_THROW(VPR_ERROR_ROUTE, "No canonical loc for %d", to_node_ind);
+        }
+
+        to_location = *to_canonical_loc;
+    }
+
+    const std::pair<size_t, size_t>* from_canonical_loc = device_ctx.connection_boxes.find_canonical_loc(from_node_ind);
+    if (from_canonical_loc == nullptr) {
+        VPR_THROW(VPR_ERROR_ROUTE, "No canonical loc for %d (to %d)",
+                  from_node_ind, to_node_ind);
+    }
+
+    ssize_t dx = ssize_t(from_canonical_loc->first) - ssize_t(to_location.first);
+    ssize_t dy = ssize_t(from_canonical_loc->second) - ssize_t(to_location.second);
+
+    int from_seg_index = g_cost_map.node_to_segment(from_node_ind);
+    Cost_Entry cost_entry = g_cost_map.find_cost(from_seg_index, dx, dy);
+    float expected_delay = cost_entry.delay;
+    float expected_congestion = cost_entry.congestion;
+
+    float expected_cost = criticality_fac * expected_delay + (1.0 - criticality_fac) * expected_congestion;
+    return expected_cost;
+}
+
+/* runs Dijkstra's algorithm from specified node until all nodes have been
+ * visited. Each time a pin is visited, the delay/congestion information
+ * to that pin is stored to an entry in the routing_cost_map */
+static void run_dijkstra(int start_node_ind,
+                         t_routing_cost_map* routing_cost_map) {
+    auto& device_ctx = g_vpr_ctx.device();
+
+    /* a list of boolean flags (one for each rr node) to figure out if a
+     * certain node has already been expanded */
+    std::vector<bool> node_expanded(device_ctx.rr_nodes.size(), false);
+    /* for each node keep a list of the cost with which that node has been
+     * visited (used to determine whether to push a candidate node onto the
+     * expansion queue */
+    std::vector<float> node_visited_costs(device_ctx.rr_nodes.size(), -1.0);
+    /* a priority queue for expansion */
+    std::priority_queue<util::PQ_Entry> pq;
+
+    /* first entry has no upstream delay or congestion */
+    util::PQ_Entry first_entry(start_node_ind, UNDEFINED, 0, 0, 0, true);
+
+    pq.push(first_entry);
+
+    const std::pair<size_t, size_t>* from_canonical_loc = device_ctx.connection_boxes.find_canonical_loc(start_node_ind);
+    if (from_canonical_loc == nullptr) {
+        VPR_THROW(VPR_ERROR_ROUTE, "No canonical location of node %d",
+                  start_node_ind);
+    }
+
+    /* now do routing */
+    while (!pq.empty()) {
+        util::PQ_Entry current = pq.top();
+        pq.pop();
+
+        int node_ind = current.rr_node_ind;
+
+        /* check that we haven't already expanded from this node */
+        if (node_expanded[node_ind]) {
+            continue;
+        }
+
+        /* if this node is an ipin record its congestion/delay in the routing_cost_map */
+        if (device_ctx.rr_nodes[node_ind].type() == IPIN) {
+            ConnectionBoxId box_id;
+            std::pair<size_t, size_t> box_location;
+            bool found = device_ctx.connection_boxes.find_connection_box(
+                node_ind, &box_id, &box_location);
+            if (!found) {
+                VPR_THROW(VPR_ERROR_ROUTE, "No connection box for IPIN %d", node_ind);
+            }
+
+            int delta_x = ssize_t(from_canonical_loc->first) - ssize_t(box_location.first);
+            int delta_y = ssize_t(from_canonical_loc->second) - ssize_t(box_location.second);
+
+            routing_cost_map->push_back(std::make_pair(
+                std::make_pair(delta_x, delta_y),
+                Cost_Entry(
+                    current.delay,
+                    current.congestion_upstream)));
+        }
+
+        expand_dijkstra_neighbours(current, node_visited_costs, node_expanded, pq);
+        node_expanded[node_ind] = true;
+    }
+}
+
+void ConnectionBoxMapLookahead::compute(const std::vector<t_segment_inf>& segment_inf) {
+    compute_connection_box_lookahead(segment_inf);
+}
+
+float ConnectionBoxMapLookahead::get_expected_cost(
+    int current_node,
+    int target_node,
+    const t_conn_cost_params& params,
+    float /*R_upstream*/) const {
+    auto& device_ctx = g_vpr_ctx.device();
+
+    t_rr_type rr_type = device_ctx.rr_nodes[current_node].type();
+
+    if (rr_type == CHANX || rr_type == CHANY) {
+        return get_connection_box_lookahead_map_cost(
+            current_node, target_node, params.criticality);
+    } else if (rr_type == IPIN) { /* Change if you're allowing route-throughs */
+        return (device_ctx.rr_indexed_data[SINK_COST_INDEX].base_cost);
+    } else { /* Change this if you want to investigate route-throughs */
+        return (0.);
+    }
+}
+
+void ConnectionBoxMapLookahead::read(const std::string& file) {
+    g_cost_map.read(file);
+}
+void ConnectionBoxMapLookahead::write(const std::string& file) const {
+    g_cost_map.write(file);
+}
+
+static void ToCostEntry(Cost_Entry* out, const VprCostEntry::Reader& in) {
+    out->delay = in.getDelay();
+    out->congestion = in.getCongestion();
+}
+
+static void FromCostEntry(VprCostEntry::Builder* out, const Cost_Entry& in) {
+    out->setDelay(in.delay);
+    out->setCongestion(in.congestion);
+}
+
+void CostMap::read(const std::string& file) {
+    MmapFile f(file);
+    ::capnp::FlatArrayMessageReader reader(f.getData());
+
+    auto cost_map = reader.getRoot<VprCostMap>();
+
+    {
+        const auto& segment_map = cost_map.getSegmentMap();
+        segment_map_.resize(segment_map.size());
+        auto dst_iter = segment_map_.begin();
+        for (const auto& src : segment_map) {
+            *dst_iter++ = src;
+        }
+    }
+
+    {
+        const auto& offset = cost_map.getOffset();
+        offset_.resize(offset.size());
+        auto dst_iter = offset_.begin();
+        for (const auto& src : offset) {
+            *dst_iter++ = std::make_pair(src.getX(), src.getY());
+        }
+    }
+
+    {
+        const auto& cost_maps = cost_map.getCostMap();
+        cost_map_.resize(cost_maps.size());
+        auto dst_iter = cost_map_.begin();
+        for (const auto& src : cost_maps) {
+            ToNdMatrix<2, VprCostEntry, Cost_Entry>(&(*dst_iter++), src, ToCostEntry);
+        }
+    }
+}
+
+void CostMap::write(const std::string& file) const {
+    ::capnp::MallocMessageBuilder builder;
+
+    auto cost_map = builder.initRoot<VprCostMap>();
+
+    {
+        auto segment_map = cost_map.initSegmentMap(segment_map_.size());
+        for (size_t i = 0; i < segment_map_.size(); ++i) {
+            segment_map.set(i, segment_map_[i]);
+        }
+    }
+
+    {
+        auto offset = cost_map.initOffset(offset_.size());
+        for (size_t i = 0; i < offset_.size(); ++i) {
+            auto elem = offset[i];
+            elem.setX(offset_[i].first);
+            elem.setY(offset_[i].second);
+        }
+    }
+
+    {
+        auto cost_maps = cost_map.initCostMap(cost_map_.size());
+        for (size_t i = 0; i < cost_map_.size(); ++i) {
+            Matrix<VprCostEntry>::Builder elem = cost_maps[i];
+            FromNdMatrix<2, VprCostEntry, Cost_Entry>(
+                &elem, cost_map_[i], FromCostEntry);
+        }
+    }
+
+    writeMessageToFile(file, &builder);
+}

--- a/vpr/src/route/connection_box_lookahead_map.cpp
+++ b/vpr/src/route/connection_box_lookahead_map.cpp
@@ -13,11 +13,13 @@
 
 #include "route_timing.h"
 
-#include "capnp/serialize.h"
-#include "connection_map.capnp.h"
-#include "ndmatrix_serdes.h"
-#include "mmap_file.h"
-#include "serdes_utils.h"
+#ifdef VTR_ENABLE_CAPNPROTO
+#    include "capnp/serialize.h"
+#    include "connection_map.capnp.h"
+#    include "ndmatrix_serdes.h"
+#    include "mmap_file.h"
+#    include "serdes_utils.h"
+#endif
 
 /* we're profiling routing cost over many tracks for each wire type, so we'll
  * have many cost entries at each |dx|,|dy| offset. There are many ways to
@@ -39,17 +41,17 @@ static int signum(int x) {
         return 0;
 }
 
-typedef std::vector<std::pair<std::pair<int, int>, Cost_Entry>> t_routing_cost_map;
+typedef std::vector<std::tuple<std::pair<int, int>, std::pair<int, int>, Cost_Entry, ConnectionBoxId>> t_routing_cost_map;
 static void run_dijkstra(int start_node_ind,
-                         t_routing_cost_map* cost_map);
+                         t_routing_cost_map* routing_cost_map);
 
 class CostMap {
   public:
-    void set_segment_count(size_t seg_count) {
+    void set_counts(size_t seg_count, size_t box_count) {
         cost_map_.clear();
         offset_.clear();
-        cost_map_.resize(seg_count);
-        offset_.resize(seg_count);
+        cost_map_.resize({seg_count, box_count});
+        offset_.resize({seg_count, box_count});
 
         const auto& device_ctx = g_vpr_ctx.device();
         segment_map_.resize(device_ctx.rr_nodes.size());
@@ -67,11 +69,11 @@ class CostMap {
         return segment_map_[from_node_ind];
     }
 
-    Cost_Entry find_cost(int from_seg_index, int delta_x, int delta_y) const {
+    Cost_Entry find_cost(int from_seg_index, ConnectionBoxId box_id, int delta_x, int delta_y) const {
         VTR_ASSERT(from_seg_index >= 0 && from_seg_index < (ssize_t)offset_.size());
-        int dx = delta_x - offset_[from_seg_index].first;
-        int dy = delta_y - offset_[from_seg_index].second;
-        const auto& cost_map = cost_map_[from_seg_index];
+        int dx = delta_x - offset_[from_seg_index][size_t(box_id)].first;
+        int dy = delta_y - offset_[from_seg_index][size_t(box_id)].second;
+        const auto& cost_map = cost_map_[from_seg_index][size_t(box_id)];
 
         if (dx < 0) {
             dx = 0;
@@ -87,12 +89,21 @@ class CostMap {
             dy = cost_map.dim_size(1) - 1;
         }
 
-        return cost_map_[from_seg_index][dx][dy];
+        return cost_map_[from_seg_index][size_t(box_id)][dx][dy];
     }
 
     void set_cost_map(int from_seg_index,
                       const t_routing_cost_map& cost_map,
                       e_representative_entry_method method) {
+        const auto& device_ctx = g_vpr_ctx.device();
+        for (size_t box_id = 0;
+             box_id < device_ctx.connection_boxes.num_connection_box_types();
+             ++box_id) {
+            set_cost_map(from_seg_index, ConnectionBoxId(box_id), cost_map, method);
+        }
+    }
+
+    void set_cost_map(int from_seg_index, ConnectionBoxId box_id, const t_routing_cost_map& cost_map, e_representative_entry_method method) {
         VTR_ASSERT(from_seg_index >= 0 && from_seg_index < (ssize_t)offset_.size());
 
         // Find coordinate offset for this segment.
@@ -101,15 +112,18 @@ class CostMap {
         int max_dx = 0;
         int max_dy = 0;
         for (const auto& entry : cost_map) {
-            min_dx = std::min(entry.first.first, min_dx);
-            min_dy = std::min(entry.first.second, min_dy);
+            if (std::get<3>(entry) != box_id) {
+                continue;
+            }
+            min_dx = std::min(std::get<1>(entry).first, min_dx);
+            min_dy = std::min(std::get<1>(entry).second, min_dy);
 
-            max_dx = std::max(entry.first.first, max_dx);
-            max_dy = std::max(entry.first.second, max_dy);
+            max_dx = std::max(std::get<1>(entry).first, max_dx);
+            max_dy = std::max(std::get<1>(entry).second, max_dy);
         }
 
-        offset_[from_seg_index].first = min_dx;
-        offset_[from_seg_index].second = min_dy;
+        offset_[from_seg_index][size_t(box_id)].first = min_dx;
+        offset_[from_seg_index][size_t(box_id)].second = min_dy;
         size_t dim_x = max_dx - min_dx + 1;
         size_t dim_y = max_dy - min_dy + 1;
 
@@ -117,41 +131,45 @@ class CostMap {
             {dim_x, dim_y});
 
         for (const auto& entry : cost_map) {
-            int x = entry.first.first - min_dx;
-            int y = entry.first.second - min_dy;
+            if (std::get<3>(entry) != box_id) {
+                continue;
+            }
+            int x = std::get<1>(entry).first - min_dx;
+            int y = std::get<1>(entry).second - min_dy;
             expansion_cost_map[x][y].add_cost_entry(
-                method, entry.second.delay,
-                entry.second.congestion);
+                method, std::get<2>(entry).delay,
+                std::get<2>(entry).congestion);
         }
 
-        cost_map_[from_seg_index] = vtr::NdMatrix<Cost_Entry, 2>(
+        cost_map_[from_seg_index][size_t(box_id)] = vtr::NdMatrix<Cost_Entry, 2>(
             {dim_x, dim_y});
 
         /* set the lookahead cost map entries with a representative cost
          * entry from routing_cost_map */
         for (unsigned ix = 0; ix < expansion_cost_map.dim_size(0); ix++) {
             for (unsigned iy = 0; iy < expansion_cost_map.dim_size(1); iy++) {
-                cost_map_[from_seg_index][ix][iy] = expansion_cost_map[ix][iy].get_representative_cost_entry(method);
+                cost_map_[from_seg_index][size_t(box_id)][ix][iy] = expansion_cost_map[ix][iy].get_representative_cost_entry(method);
             }
         }
 
         /* find missing cost entries and fill them in by copying a nearby cost entry */
         for (unsigned ix = 0; ix < expansion_cost_map.dim_size(0); ix++) {
             for (unsigned iy = 0; iy < expansion_cost_map.dim_size(1); iy++) {
-                Cost_Entry cost_entry = cost_map_[from_seg_index][ix][iy];
+                Cost_Entry cost_entry = cost_map_[from_seg_index][size_t(box_id)][ix][iy];
 
                 if (!cost_entry.valid()) {
                     Cost_Entry copied_entry = get_nearby_cost_entry(
                         from_seg_index,
-                        offset_[from_seg_index].first + ix,
-                        offset_[from_seg_index].second + iy);
-                    cost_map_[from_seg_index][ix][iy] = copied_entry;
+                        box_id,
+                        offset_[from_seg_index][size_t(box_id)].first + ix,
+                        offset_[from_seg_index][size_t(box_id)].second + iy);
+                    cost_map_[from_seg_index][size_t(box_id)][ix][iy] = copied_entry;
                 }
             }
         }
     }
 
-    Cost_Entry get_nearby_cost_entry(int segment_index, int x, int y) {
+    Cost_Entry get_nearby_cost_entry(int segment_index, ConnectionBoxId box_id, int x, int y) {
         /* compute the slope from x,y to 0,0 and then move towards 0,0 by one
          * unit to get the coordinates of the cost entry to be copied */
 
@@ -172,7 +190,7 @@ class CostMap {
             }
         }
 
-        Cost_Entry copy_entry = find_cost(segment_index, copy_x, copy_y);
+        Cost_Entry copy_entry = find_cost(segment_index, box_id, copy_x, copy_y);
 
         /* if the entry to be copied is also empty, recurse */
         if (copy_entry.valid()) {
@@ -181,40 +199,30 @@ class CostMap {
             return Cost_Entry();
         }
 
-        return get_nearby_cost_entry(segment_index, copy_x, copy_y);
-    }
-
-    void print_cost_map(const std::vector<t_segment_inf>& segment_inf,
-                        const char* fname) {
-        FILE* fp = vtr::fopen(fname, "w");
-        for (size_t iseg = 0; iseg < cost_map_.size(); iseg++) {
-            fprintf(fp, "Seg %s(%zu) (%d, %d)\n", segment_inf.at(iseg).name.c_str(),
-                    iseg,
-                    offset_[iseg].first,
-                    offset_[iseg].second);
-            for (size_t iy = 0; iy < cost_map_[iseg].dim_size(1); iy++) {
-                for (size_t ix = 0; ix < cost_map_[iseg].dim_size(0); ix++) {
-                    fprintf(fp, "%.4g,\t",
-                            cost_map_[iseg][ix][iy].delay);
-                }
-                fprintf(fp, "\n");
-            }
-            fprintf(fp, "\n\n");
-        }
-
-        fclose(fp);
+        return get_nearby_cost_entry(segment_index, box_id, copy_x, copy_y);
     }
 
     void read(const std::string& file);
     void write(const std::string& file) const;
 
   private:
-    std::vector<vtr::NdMatrix<Cost_Entry, 2>> cost_map_;
-    std::vector<std::pair<int, int>> offset_;
+    vtr::NdMatrix<vtr::NdMatrix<Cost_Entry, 2>, 2> cost_map_;
+    vtr::NdMatrix<std::pair<int, int>, 2> offset_;
     std::vector<int> segment_map_;
 };
 
 static CostMap g_cost_map;
+
+const std::vector<int>& get_rr_node_indcies(t_rr_type rr_type, int start_x, int start_y) {
+    const auto& device_ctx = g_vpr_ctx.device();
+    if (rr_type == CHANX) {
+        return device_ctx.rr_node_indices[rr_type][start_y][start_x][0];
+    } else if (rr_type == CHANY) {
+        return device_ctx.rr_node_indices[rr_type][start_x][start_y][0];
+    } else {
+        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Unknown channel type %d", rr_type);
+    }
+}
 
 class StartNode {
   public:
@@ -226,7 +234,8 @@ class StartNode {
         , index_(0) {}
     int get_next_node() {
         const auto& device_ctx = g_vpr_ctx.device();
-        const std::vector<int>& channel_node_list = device_ctx.rr_node_indices[rr_type_][start_x_][start_y_][0];
+        const std::vector<int>& channel_node_list = get_rr_node_indcies(
+            rr_type_, start_x_, start_y_);
 
         for (; index_ < channel_node_list.size(); index_++) {
             int node_ind = channel_node_list[index_];
@@ -272,13 +281,45 @@ static constexpr int kMinProfile = 1;
 //  - kMaxProfile is exceeded.
 static constexpr int kMaxProfile = 7;
 
+static int search_at(int iseg, int start_x, int start_y, t_routing_cost_map* cost_map) {
+    int count = 0;
+    int dx = 0;
+    int dy = 0;
+
+    while ((count == 0 && dx < kMaxProfile) || dy <= kMinProfile) {
+        for (e_rr_type chan_type : {CHANX, CHANY}) {
+            StartNode start_node(start_x + dx, start_y + dy, chan_type, iseg);
+            VTR_LOG("Searching for %d at (%d, %d)\n", iseg, start_x + dx, start_y + dy);
+
+            for (int start_node_ind = start_node.get_next_node();
+                 start_node_ind != UNDEFINED;
+                 start_node_ind = start_node.get_next_node()) {
+                count += 1;
+
+                /* run Dijkstra's algorithm */
+                run_dijkstra(start_node_ind, cost_map);
+            }
+        }
+
+        if (dy < dx) {
+            dy += 1;
+        } else {
+            dx += 1;
+        }
+    }
+
+    return count;
+}
+
 static void compute_connection_box_lookahead(
     const std::vector<t_segment_inf>& segment_inf) {
     size_t num_segments = segment_inf.size();
     vtr::ScopedStartFinishTimer timer("Computing connection box lookahead map");
 
     /* free previous delay map and allocate new one */
-    g_cost_map.set_segment_count(segment_inf.size());
+    auto& device_ctx = g_vpr_ctx.device();
+    g_cost_map.set_counts(segment_inf.size(),
+                          device_ctx.connection_boxes.num_connection_box_types());
 
     /* run Dijkstra's algorithm for each segment type & channel type combination */
     for (int iseg = 0; iseg < (ssize_t)num_segments; iseg++) {
@@ -288,47 +329,32 @@ static void compute_connection_box_lookahead(
         t_routing_cost_map cost_map;
 
         int count = 0;
-
-        int dx = 0;
-        int dy = 0;
-        //int start_x = vtr::nint(device_ctx.grid.width()/2);
-        //int start_y = vtr::nint(device_ctx.grid.height()/2);
-        int start_x = REF_X;
-        int start_y = REF_Y;
-        while ((count == 0 && dx < kMaxProfile) || dy <= kMinProfile) {
-            for (e_rr_type chan_type : {CHANX, CHANY}) {
-                StartNode start_node(start_x + dx, start_y + dy, chan_type, iseg);
-
-                for (int start_node_ind = start_node.get_next_node();
-                     start_node_ind != UNDEFINED;
-                     start_node_ind = start_node.get_next_node()) {
-                    count += 1;
-
-                    /* run Dijkstra's algorithm */
-                    run_dijkstra(start_node_ind, &cost_map);
-                }
-            }
-
-            if (dy < dx) {
-                dy += 1;
-            } else {
-                dx += 1;
-            }
-        }
+        count += search_at(iseg, REF_X, REF_Y, &cost_map);
+        count += search_at(iseg, REF_Y, REF_X, &cost_map);
+        count += search_at(iseg, 1, 1, &cost_map);
+        count += search_at(iseg, 76, 1, &cost_map);
+        count += search_at(iseg, 25, 25, &cost_map);
+        count += search_at(iseg, 25, 27, &cost_map);
+        count += search_at(iseg, 75, 26, &cost_map);
 
         if (count == 0) {
             VTR_LOG_WARN("Segment %s(%d) found no start_node_ind\n",
                          segment_inf[iseg].name.c_str(), iseg);
         }
 
+#if 0
+        for(const auto & e : cost_map) {
+            VTR_LOG("%d -> %d (%d, %d): %g, %g\n",
+                    std::get<0>(e).first, std::get<0>(e).second,
+                    std::get<1>(e).first, std::get<1>(e).second,
+                    std::get<2>(e).delay, std::get<2>(e).congestion);
+        }
+#endif
+
         /* boil down the cost list in routing_cost_map at each coordinate to a
          * representative cost entry and store it in the lookahead cost map */
         g_cost_map.set_cost_map(iseg, cost_map,
                                 REPRESENTATIVE_ENTRY_METHOD);
-    }
-
-    if (getEchoEnabled() && isEchoFileEnabled(E_ECHO_LOOKAHEAD_MAP)) {
-        g_cost_map.print_cost_map(segment_inf, getEchoFileName(E_ECHO_LOOKAHEAD_MAP));
     }
 }
 
@@ -368,23 +394,15 @@ static float get_connection_box_lookahead_map_cost(int from_node_ind,
         }
     }
 
-    if (device_ctx.rr_nodes[to_node_ind].type() == IPIN) {
-        ConnectionBoxId box_id;
-        std::pair<size_t, size_t> box_location;
-        bool found = device_ctx.connection_boxes.find_connection_box(
-            to_node_ind, &box_id, &box_location);
-        if (!found) {
-            VPR_THROW(VPR_ERROR_ROUTE, "No connection box for IPIN %d", to_node_ind);
-        }
-
-        to_location = box_location;
-    } else {
-        const std::pair<size_t, size_t>* to_canonical_loc = device_ctx.connection_boxes.find_canonical_loc(to_node_ind);
-        if (!to_canonical_loc) {
-            VPR_THROW(VPR_ERROR_ROUTE, "No canonical loc for %d", to_node_ind);
-        }
-
-        to_location = *to_canonical_loc;
+    if (device_ctx.rr_nodes[to_node_ind].type() != IPIN) {
+        VPR_THROW(VPR_ERROR_ROUTE, "Not an IPIN/SINK, is %d", to_node_ind);
+    }
+    ConnectionBoxId box_id;
+    std::pair<size_t, size_t> box_location;
+    bool found = device_ctx.connection_boxes.find_connection_box(
+        to_node_ind, &box_id, &box_location);
+    if (!found) {
+        VPR_THROW(VPR_ERROR_ROUTE, "No connection box for IPIN %d", to_node_ind);
     }
 
     const std::pair<size_t, size_t>* from_canonical_loc = device_ctx.connection_boxes.find_canonical_loc(from_node_ind);
@@ -393,11 +411,11 @@ static float get_connection_box_lookahead_map_cost(int from_node_ind,
                   from_node_ind, to_node_ind);
     }
 
-    ssize_t dx = ssize_t(from_canonical_loc->first) - ssize_t(to_location.first);
-    ssize_t dy = ssize_t(from_canonical_loc->second) - ssize_t(to_location.second);
+    ssize_t dx = ssize_t(from_canonical_loc->first) - ssize_t(box_location.first);
+    ssize_t dy = ssize_t(from_canonical_loc->second) - ssize_t(box_location.second);
 
     int from_seg_index = g_cost_map.node_to_segment(from_node_ind);
-    Cost_Entry cost_entry = g_cost_map.find_cost(from_seg_index, dx, dy);
+    Cost_Entry cost_entry = g_cost_map.find_cost(from_seg_index, box_id, dx, dy);
     float expected_delay = cost_entry.delay;
     float expected_congestion = cost_entry.congestion;
 
@@ -458,11 +476,13 @@ static void run_dijkstra(int start_node_ind,
             int delta_x = ssize_t(from_canonical_loc->first) - ssize_t(box_location.first);
             int delta_y = ssize_t(from_canonical_loc->second) - ssize_t(box_location.second);
 
-            routing_cost_map->push_back(std::make_pair(
+            routing_cost_map->push_back(std::make_tuple(
+                std::make_pair(start_node_ind, node_ind),
                 std::make_pair(delta_x, delta_y),
                 Cost_Entry(
                     current.delay,
-                    current.congestion_upstream)));
+                    current.congestion_upstream),
+                box_id));
         }
 
         expand_dijkstra_neighbours(current, node_visited_costs, node_expanded, pq);
@@ -493,6 +513,17 @@ float ConnectionBoxMapLookahead::get_expected_cost(
     }
 }
 
+#ifndef VTR_ENABLE_CAPNPROTO
+
+void ConnectionBoxMapLookahead::read(const std::string& file) {
+    VPR_THROW(VPR_ERROR_ROUTE, "ConnectionBoxMapLookahead::read not implemented");
+}
+void ConnectionBoxMapLookahead::write(const std::string& file) const {
+    VPR_THROW(VPR_ERROR_ROUTE, "ConnectionBoxMapLookahead::write not implemented");
+}
+
+#else
+
 void ConnectionBoxMapLookahead::read(const std::string& file) {
     g_cost_map.read(file);
 }
@@ -508,6 +539,27 @@ static void ToCostEntry(Cost_Entry* out, const VprCostEntry::Reader& in) {
 static void FromCostEntry(VprCostEntry::Builder* out, const Cost_Entry& in) {
     out->setDelay(in.delay);
     out->setCongestion(in.congestion);
+}
+
+static void ToVprVector2D(std::pair<int, int>* out, const VprVector2D::Reader& in) {
+    *out = std::make_pair(in.getX(), in.getY());
+}
+
+static void FromVprVector2D(VprVector2D::Builder* out, const std::pair<int, int>& in) {
+    out->setX(in.first);
+    out->setY(in.second);
+}
+
+static void ToMatrixCostEntry(vtr::NdMatrix<Cost_Entry, 2>* out,
+                              const Matrix<VprCostEntry>::Reader& in) {
+    ToNdMatrix<2, VprCostEntry, Cost_Entry>(out, in, ToCostEntry);
+}
+
+static void FromMatrixCostEntry(
+    Matrix<VprCostEntry>::Builder* out,
+    const vtr::NdMatrix<Cost_Entry, 2>& in) {
+    FromNdMatrix<2, VprCostEntry, Cost_Entry>(
+        out, in, FromCostEntry);
 }
 
 void CostMap::read(const std::string& file) {
@@ -527,20 +579,14 @@ void CostMap::read(const std::string& file) {
 
     {
         const auto& offset = cost_map.getOffset();
-        offset_.resize(offset.size());
-        auto dst_iter = offset_.begin();
-        for (const auto& src : offset) {
-            *dst_iter++ = std::make_pair(src.getX(), src.getY());
-        }
+        ToNdMatrix<2, VprVector2D, std::pair<int, int>>(
+            &offset_, offset, ToVprVector2D);
     }
 
     {
         const auto& cost_maps = cost_map.getCostMap();
-        cost_map_.resize(cost_maps.size());
-        auto dst_iter = cost_map_.begin();
-        for (const auto& src : cost_maps) {
-            ToNdMatrix<2, VprCostEntry, Cost_Entry>(&(*dst_iter++), src, ToCostEntry);
-        }
+        ToNdMatrix<2, Matrix<VprCostEntry>, vtr::NdMatrix<Cost_Entry, 2>>(
+            &cost_map_, cost_maps, ToMatrixCostEntry);
     }
 }
 
@@ -557,22 +603,17 @@ void CostMap::write(const std::string& file) const {
     }
 
     {
-        auto offset = cost_map.initOffset(offset_.size());
-        for (size_t i = 0; i < offset_.size(); ++i) {
-            auto elem = offset[i];
-            elem.setX(offset_[i].first);
-            elem.setY(offset_[i].second);
-        }
+        auto offset = cost_map.initOffset();
+        FromNdMatrix<2, VprVector2D, std::pair<int, int>>(
+            &offset, offset_, FromVprVector2D);
     }
 
     {
-        auto cost_maps = cost_map.initCostMap(cost_map_.size());
-        for (size_t i = 0; i < cost_map_.size(); ++i) {
-            Matrix<VprCostEntry>::Builder elem = cost_maps[i];
-            FromNdMatrix<2, VprCostEntry, Cost_Entry>(
-                &elem, cost_map_[i], FromCostEntry);
-        }
+        auto cost_maps = cost_map.initCostMap();
+        FromNdMatrix<2, Matrix<VprCostEntry>, vtr::NdMatrix<Cost_Entry, 2>>(
+            &cost_maps, cost_map_, FromMatrixCostEntry);
     }
 
     writeMessageToFile(file, &builder);
 }
+#endif

--- a/vpr/src/route/connection_box_lookahead_map.cpp
+++ b/vpr/src/route/connection_box_lookahead_map.cpp
@@ -213,7 +213,7 @@ class CostMap {
 
 static CostMap g_cost_map;
 
-const std::vector<int>& get_rr_node_indcies(t_rr_type rr_type, int start_x, int start_y) {
+static const std::vector<int>& get_rr_node_indcies(t_rr_type rr_type, int start_x, int start_y) {
     const auto& device_ctx = g_vpr_ctx.device();
     if (rr_type == CHANX) {
         return device_ctx.rr_node_indices[rr_type][start_y][start_x][0];

--- a/vpr/src/route/connection_box_lookahead_map.cpp
+++ b/vpr/src/route/connection_box_lookahead_map.cpp
@@ -282,11 +282,20 @@ static constexpr int kMinProfile = 1;
 static constexpr int kMaxProfile = 7;
 
 static int search_at(int iseg, int start_x, int start_y, t_routing_cost_map* cost_map) {
+    const auto& device_ctx = g_vpr_ctx.device();
+
     int count = 0;
     int dx = 0;
     int dy = 0;
 
     while ((count == 0 && dx < kMaxProfile) || dy <= kMinProfile) {
+        if (start_x + dx >= device_ctx.grid.width()) {
+            break;
+        }
+        if (start_y + dy >= device_ctx.grid.height()) {
+            break;
+        }
+
         for (e_rr_type chan_type : {CHANX, CHANY}) {
             StartNode start_node(start_x + dx, start_y + dy, chan_type, iseg);
             VTR_LOG("Searching for %d at (%d, %d)\n", iseg, start_x + dx, start_y + dy);

--- a/vpr/src/route/connection_box_lookahead_map.h
+++ b/vpr/src/route/connection_box_lookahead_map.h
@@ -8,7 +8,7 @@
 class ConnectionBoxMapLookahead : public RouterLookahead {
   public:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
-    void compute(const std::vector<t_segment_inf>& segment_inf) override;
+    void compute(const std::vector<t_segment_inf>& segment_inf, const std::string& lookahead_search_locations) override;
 
     void read(const std::string& file) override;
     void write(const std::string& file) const override;

--- a/vpr/src/route/connection_box_lookahead_map.h
+++ b/vpr/src/route/connection_box_lookahead_map.h
@@ -1,0 +1,17 @@
+#ifndef CONNECTION_BOX_LOOKAHEAD_H_
+#define CONNECTION_BOX_LOOKAHEAD_H_
+
+#include <vector>
+#include "physical_types.h"
+#include "router_lookahead.h"
+
+class ConnectionBoxMapLookahead : public RouterLookahead {
+  public:
+    float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    void compute(const std::vector<t_segment_inf>& segment_inf) override;
+
+    void read(const std::string& file) override;
+    void write(const std::string& file) const override;
+};
+
+#endif

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -359,7 +359,8 @@ bool try_timing_driven_route(const t_router_opts& router_opts,
         router_opts.lookahead_type,
         router_opts.write_router_lookahead,
         router_opts.read_router_lookahead,
-        segment_inf);
+        segment_inf,
+        router_opts.lookahead_search_locations);
 
     /*
      * Routing parameters
@@ -1372,7 +1373,8 @@ std::vector<t_heap> timing_driven_find_all_shortest_paths_from_route_tree(t_rt_n
     int target_node = OPEN;
     auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP,
                                                   /*write_lookahead=*/"", /*read_lookahead=*/"",
-                                                  /*segment_inf=*/{});
+                                                  /*segment_inf=*/{},
+                                                  /*lookahead_search_locations=*/"");
     add_route_tree_to_heap(rt_root, target_node, cost_params, *router_lookahead, router_stats);
     heap_::build_heap(); // via sifting down everything
 
@@ -1394,7 +1396,8 @@ static std::vector<t_heap> timing_driven_find_all_shortest_paths_from_heap(const
                                                                            RouterStats& router_stats) {
     auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP,
                                                   /*write_lookahead=*/"", /*read_lookahead=*/"",
-                                                  /*segment_inf=*/{});
+                                                  /*segment_inf=*/{},
+                                                  /*lookahead_search_locations=*/"");
 
     auto& device_ctx = g_vpr_ctx.device();
     std::vector<t_heap> cheapest_paths(device_ctx.rr_nodes.size());

--- a/vpr/src/route/router_lookahead.cpp
+++ b/vpr/src/route/router_lookahead.cpp
@@ -28,11 +28,12 @@ std::unique_ptr<RouterLookahead> make_router_lookahead(
     e_router_lookahead router_lookahead_type,
     std::string write_lookahead,
     std::string read_lookahead,
-    const std::vector<t_segment_inf>& segment_inf) {
+    const std::vector<t_segment_inf>& segment_inf,
+    const std::string& lookahead_search_locations) {
     std::unique_ptr<RouterLookahead> router_lookahead = make_router_lookahead_object(router_lookahead_type);
 
     if (read_lookahead.empty()) {
-        router_lookahead->compute(segment_inf);
+        router_lookahead->compute(segment_inf, lookahead_search_locations);
     } else {
         router_lookahead->read(read_lookahead);
     }
@@ -104,7 +105,8 @@ float MapLookahead::get_expected_cost(int current_node, int target_node, const t
     }
 }
 
-void MapLookahead::compute(const std::vector<t_segment_inf>& segment_inf) {
+void MapLookahead::compute(const std::vector<t_segment_inf>& segment_inf,
+                           const std::string& lookahead_search_locations) {
     compute_router_lookahead(segment_inf.size());
 }
 
@@ -206,10 +208,11 @@ const RouterLookahead* get_cached_router_lookahead(
     e_router_lookahead router_lookahead_type,
     std::string write_lookahead,
     std::string read_lookahead,
-    const std::vector<t_segment_inf>& segment_inf) {
+    const std::vector<t_segment_inf>& segment_inf,
+    const std::string& lookahead_search_locations) {
     auto& router_ctx = g_vpr_ctx.routing();
 
-    auto cache_key = std::make_tuple(router_lookahead_type, read_lookahead, segment_inf);
+    auto cache_key = std::make_tuple(router_lookahead_type, read_lookahead, segment_inf, lookahead_search_locations);
 
     // Check if cache is valid.
     const RouterLookahead* router_lookahead = router_ctx.cached_router_lookahead_.get(cache_key);
@@ -225,6 +228,7 @@ const RouterLookahead* get_cached_router_lookahead(
                 router_lookahead_type,
                 write_lookahead,
                 read_lookahead,
-                segment_inf));
+                segment_inf,
+                lookahead_search_locations));
     }
 }

--- a/vpr/src/route/router_lookahead.cpp
+++ b/vpr/src/route/router_lookahead.cpp
@@ -1,6 +1,7 @@
 #include "router_lookahead.h"
 
 #include "router_lookahead_map.h"
+#include "connection_box_lookahead_map.h"
 #include "vpr_error.h"
 #include "globals.h"
 #include "route_timing.h"
@@ -13,6 +14,8 @@ static std::unique_ptr<RouterLookahead> make_router_lookahead_object(e_router_lo
         return std::make_unique<ClassicLookahead>();
     } else if (router_lookahead_type == e_router_lookahead::MAP) {
         return std::make_unique<MapLookahead>();
+    } else if (router_lookahead_type == e_router_lookahead::CONNECTION_BOX_MAP) {
+        return std::make_unique<ConnectionBoxMapLookahead>();
     } else if (router_lookahead_type == e_router_lookahead::NO_OP) {
         return std::make_unique<NoOpLookahead>();
     }

--- a/vpr/src/route/router_lookahead.h
+++ b/vpr/src/route/router_lookahead.h
@@ -15,7 +15,7 @@ class RouterLookahead {
     virtual float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const = 0;
 
     // Compute router lookahead (if needed).
-    virtual void compute(const std::vector<t_segment_inf>& segment_inf) = 0;
+    virtual void compute(const std::vector<t_segment_inf>& segment_inf, const std::string& lookahead_search_locations) = 0;
 
     // Read router lookahead data (if any) from specified file.
     // May be unimplemented, in which case method should throw an exception.
@@ -36,7 +36,8 @@ std::unique_ptr<RouterLookahead> make_router_lookahead(
     e_router_lookahead router_lookahead_type,
     std::string write_lookahead,
     std::string read_lookahead,
-    const std::vector<t_segment_inf>& segment_inf);
+    const std::vector<t_segment_inf>& segment_inf,
+    const std::string& lookahead_search_locations);
 
 // Clear router lookahead cache (e.g. when changing or free rrgraph).
 void invalidate_router_lookahead_cache();
@@ -49,12 +50,14 @@ const RouterLookahead* get_cached_router_lookahead(
     e_router_lookahead router_lookahead_type,
     std::string write_lookahead,
     std::string read_lookahead,
-    const std::vector<t_segment_inf>& segment_inf);
+    const std::vector<t_segment_inf>& segment_inf,
+    const std::string& lookahead_search_locations);
 
 class ClassicLookahead : public RouterLookahead {
   public:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
-    void compute(const std::vector<t_segment_inf>& /*segment_inf*/) override {
+    void compute(const std::vector<t_segment_inf>& /*segment_inf*/,
+                 const std::string& /*lookahead_search_locations*/) override {
     }
 
     void read(const std::string& /*file*/) override {
@@ -71,7 +74,8 @@ class ClassicLookahead : public RouterLookahead {
 class MapLookahead : public RouterLookahead {
   protected:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
-    void compute(const std::vector<t_segment_inf>& segment_inf) override;
+    void compute(const std::vector<t_segment_inf>& segment_inf,
+                 const std::string& /*lookahead_search_locations*/) override;
     void read(const std::string& /*file*/) override {
         VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::read unimplemented");
     }
@@ -83,7 +87,8 @@ class MapLookahead : public RouterLookahead {
 class NoOpLookahead : public RouterLookahead {
   protected:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
-    void compute(const std::vector<t_segment_inf>& /*segment_inf*/) override {
+    void compute(const std::vector<t_segment_inf>& /*segment_inf*/,
+                 const std::string& /*lookahead_search_locations*/) override {
     }
     void read(const std::string& /*file*/) override {
         VPR_THROW(VPR_ERROR_ROUTE, "Read not supported for NoOpLookahead");

--- a/vpr/src/route/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead_map_utils.cpp
@@ -1,0 +1,192 @@
+#include "router_lookahead_map_utils.h"
+
+#include "globals.h"
+#include "vpr_context.h"
+#include "vtr_math.h"
+
+/* Number of CLBs I think the average conn. goes. */
+static const int CLB_DIST = 3;
+
+util::PQ_Entry::PQ_Entry(
+    int set_rr_node_ind,
+    int switch_ind,
+    float parent_delay,
+    float parent_R_upstream,
+    float parent_congestion_upstream,
+    bool starting_node) {
+    this->rr_node_ind = set_rr_node_ind;
+
+    auto& device_ctx = g_vpr_ctx.device();
+    this->delay = parent_delay;
+    this->congestion_upstream = parent_congestion_upstream;
+    this->R_upstream = parent_R_upstream;
+    if (!starting_node) {
+        int cost_index = device_ctx.rr_nodes[set_rr_node_ind].cost_index();
+
+        float Tsw = device_ctx.rr_switch_inf[switch_ind].Tdel;
+        float Rsw = device_ctx.rr_switch_inf[switch_ind].R;
+        float Cnode = device_ctx.rr_nodes[set_rr_node_ind].C();
+        float Rnode = device_ctx.rr_nodes[set_rr_node_ind].R();
+
+        float T_linear = 0.f;
+        float T_quadratic = 0.f;
+        if (device_ctx.rr_switch_inf[switch_ind].buffered()) {
+            T_linear = Tsw + Rsw * Cnode + 0.5 * Rnode * Cnode;
+            T_quadratic = 0.;
+        } else { /* Pass transistor */
+            T_linear = Tsw + 0.5 * Rsw * Cnode;
+            T_quadratic = (Rsw + Rnode) * 0.5 * Cnode;
+        }
+
+        float base_cost;
+        if (device_ctx.rr_indexed_data[cost_index].inv_length < 0) {
+            base_cost = device_ctx.rr_indexed_data[cost_index].base_cost;
+        } else {
+            float frac_num_seg = CLB_DIST * device_ctx.rr_indexed_data[cost_index].inv_length;
+
+            base_cost = frac_num_seg * T_linear
+                        + frac_num_seg * frac_num_seg * T_quadratic;
+        }
+
+        VTR_ASSERT(T_linear >= 0.);
+        VTR_ASSERT(base_cost >= 0.);
+        this->delay += T_linear;
+
+        this->congestion_upstream += base_cost;
+    }
+
+    /* set the cost of this node */
+    this->cost = this->delay;
+}
+
+/* returns cost entry with the smallest delay */
+Cost_Entry Expansion_Cost_Entry::get_smallest_entry() const {
+    Cost_Entry smallest_entry;
+
+    for (auto entry : this->cost_vector) {
+        if (!smallest_entry.valid() || entry.delay < smallest_entry.delay) {
+            smallest_entry = entry;
+        }
+    }
+
+    return smallest_entry;
+}
+
+/* returns a cost entry that represents the average of all the recorded entries */
+Cost_Entry Expansion_Cost_Entry::get_average_entry() const {
+    float avg_delay = 0;
+    float avg_congestion = 0;
+
+    for (auto cost_entry : this->cost_vector) {
+        avg_delay += cost_entry.delay;
+        avg_congestion += cost_entry.congestion;
+    }
+
+    avg_delay /= (float)this->cost_vector.size();
+    avg_congestion /= (float)this->cost_vector.size();
+
+    return Cost_Entry(avg_delay, avg_congestion);
+}
+
+/* returns a cost entry that represents the geomean of all the recorded entries */
+Cost_Entry Expansion_Cost_Entry::get_geomean_entry() const {
+    float geomean_delay = 0;
+    float geomean_cong = 0;
+    for (auto cost_entry : this->cost_vector) {
+        geomean_delay += log(cost_entry.delay);
+        geomean_cong += log(cost_entry.congestion);
+    }
+
+    geomean_delay = exp(geomean_delay / (float)this->cost_vector.size());
+    geomean_cong = exp(geomean_cong / (float)this->cost_vector.size());
+
+    return Cost_Entry(geomean_delay, geomean_cong);
+}
+
+/* returns a cost entry that represents the medial of all recorded entries */
+Cost_Entry Expansion_Cost_Entry::get_median_entry() const {
+    /* find median by binning the delays of all entries and then chosing the bin
+     * with the largest number of entries */
+
+    int num_bins = 10;
+
+    /* find entries with smallest and largest delays */
+    Cost_Entry min_del_entry;
+    Cost_Entry max_del_entry;
+    for (auto entry : this->cost_vector) {
+        if (!min_del_entry.valid() || entry.delay < min_del_entry.delay) {
+            min_del_entry = entry;
+        }
+        if (!max_del_entry.valid() || entry.delay > max_del_entry.delay) {
+            max_del_entry = entry;
+        }
+    }
+
+    /* get the bin size */
+    float delay_diff = max_del_entry.delay - min_del_entry.delay;
+    float bin_size = delay_diff / (float)num_bins;
+
+    /* sort the cost entries into bins */
+    std::vector<std::vector<Cost_Entry> > entry_bins(num_bins, std::vector<Cost_Entry>());
+    for (auto entry : this->cost_vector) {
+        float bin_num = floor((entry.delay - min_del_entry.delay) / bin_size);
+
+        VTR_ASSERT(vtr::nint(bin_num) >= 0 && vtr::nint(bin_num) <= num_bins);
+        if (vtr::nint(bin_num) == num_bins) {
+            /* largest entry will otherwise have an out-of-bounds bin number */
+            bin_num -= 1;
+        }
+        entry_bins[vtr::nint(bin_num)].push_back(entry);
+    }
+
+    /* find the bin with the largest number of elements */
+    int largest_bin = 0;
+    int largest_size = 0;
+    for (int ibin = 0; ibin < num_bins; ibin++) {
+        if (entry_bins[ibin].size() > (unsigned)largest_size) {
+            largest_bin = ibin;
+            largest_size = (unsigned)entry_bins[ibin].size();
+        }
+    }
+
+    /* get the representative delay of the largest bin */
+    Cost_Entry representative_entry = entry_bins[largest_bin][0];
+
+    return representative_entry;
+}
+
+/* iterates over the children of the specified node and selectively pushes them onto the priority queue */
+void expand_dijkstra_neighbours(util::PQ_Entry parent_entry,
+                                std::vector<float>& node_visited_costs,
+                                std::vector<bool>& node_expanded,
+                                std::priority_queue<util::PQ_Entry>& pq) {
+    auto& device_ctx = g_vpr_ctx.device();
+
+    int parent_ind = parent_entry.rr_node_ind;
+
+    auto& parent_node = device_ctx.rr_nodes[parent_ind];
+
+    for (int iedge = 0; iedge < parent_node.num_edges(); iedge++) {
+        int child_node_ind = parent_node.edge_sink_node(iedge);
+        int switch_ind = parent_node.edge_switch(iedge);
+
+        /* skip this child if it has already been expanded from */
+        if (node_expanded[child_node_ind]) {
+            continue;
+        }
+
+        util::PQ_Entry child_entry(child_node_ind, switch_ind, parent_entry.delay,
+                                   parent_entry.R_upstream, parent_entry.congestion_upstream, false);
+
+        VTR_ASSERT(child_entry.cost >= 0);
+
+        /* skip this child if it has been visited with smaller cost */
+        if (node_visited_costs[child_node_ind] >= 0 && node_visited_costs[child_node_ind] < child_entry.cost) {
+            continue;
+        }
+
+        /* finally, record the cost with which the child was visited and put the child entry on the queue */
+        node_visited_costs[child_node_ind] = child_entry.cost;
+        pq.push(child_entry);
+    }
+}

--- a/vpr/src/route/router_lookahead_map_utils.h
+++ b/vpr/src/route/router_lookahead_map_utils.h
@@ -1,0 +1,144 @@
+#ifndef ROUTER_LOOKAHEAD_MAP_UTILS_H_
+#define ROUTER_LOOKAHEAD_MAP_UTILS_H_
+/*
+ * The router lookahead provides an estimate of the cost from an intermediate node to the target node
+ * during directed (A*-like) routing.
+ *
+ * The VPR 7.0 lookahead (route/route_timing.c ==> get_timing_driven_expected_cost) lower-bounds the remaining delay and
+ * congestion by assuming that a minimum number of wires, of the same type as the current node being expanded, can be used
+ * to complete the route. While this method is efficient, it can run into trouble with architectures that use
+ * multiple interconnected wire types.
+ *
+ * The lookahead in this file pre-computes delay/congestion costs up and to the right of a starting tile. This generates
+ * delay/congestion tables for {CHANX, CHANY} channel types, over all wire types defined in the architecture file.
+ * See Section 3.2.4 in Oleg Petelin's MASc thesis (2016) for more discussion.
+ *
+ */
+
+#include <cmath>
+#include <limits>
+#include <vector>
+#include <queue>
+#include "vpr_types.h"
+
+/* when a list of delay/congestion entries at a coordinate in Cost_Entry is boiled down to a single
+ * representative entry, this enum is passed-in to specify how that representative entry should be
+ * calculated */
+enum e_representative_entry_method {
+    FIRST = 0, //the first cost that was recorded
+    SMALLEST,  //the smallest-delay cost recorded
+    AVERAGE,
+    GEOMEAN,
+    MEDIAN
+};
+
+/* f_cost_map is an array of these cost entries that specifies delay/congestion estimates
+ * to travel relative x/y distances */
+class Cost_Entry {
+  public:
+    float delay;
+    float congestion;
+
+    Cost_Entry() {
+        delay = std::numeric_limits<float>::infinity();
+        congestion = std::numeric_limits<float>::infinity();
+    }
+    Cost_Entry(float set_delay, float set_congestion) {
+        delay = set_delay;
+        congestion = set_congestion;
+    }
+
+    bool valid() const {
+        return std::isfinite(delay) && std::isfinite(congestion);
+    }
+};
+
+/* a class that stores delay/congestion information for a given relative coordinate during the Dijkstra expansion.
+ * since it stores multiple cost entries, it is later boiled down to a single representative cost entry to be stored
+ * in the final lookahead cost map */
+class Expansion_Cost_Entry {
+  private:
+    std::vector<Cost_Entry> cost_vector;
+
+    Cost_Entry get_smallest_entry() const;
+    Cost_Entry get_average_entry() const;
+    Cost_Entry get_geomean_entry() const;
+    Cost_Entry get_median_entry() const;
+
+  public:
+    void add_cost_entry(e_representative_entry_method method,
+                        float add_delay,
+                        float add_congestion) {
+        Cost_Entry cost_entry(add_delay, add_congestion);
+        if (method == SMALLEST) {
+            /* taking the smallest-delay entry anyway, so no need to push back multple entries */
+            if (this->cost_vector.empty()) {
+                this->cost_vector.push_back(cost_entry);
+            } else {
+                if (add_delay < this->cost_vector[0].delay) {
+                    this->cost_vector[0] = cost_entry;
+                }
+            }
+        } else {
+            this->cost_vector.push_back(cost_entry);
+        }
+    }
+    void clear_cost_entries() {
+        this->cost_vector.clear();
+    }
+
+    Cost_Entry get_representative_cost_entry(e_representative_entry_method method) const {
+        Cost_Entry entry;
+
+        if (!cost_vector.empty()) {
+            switch (method) {
+                case FIRST:
+                    entry = cost_vector[0];
+                    break;
+                case SMALLEST:
+                    entry = this->get_smallest_entry();
+                    break;
+                case AVERAGE:
+                    entry = this->get_average_entry();
+                    break;
+                case GEOMEAN:
+                    entry = this->get_geomean_entry();
+                    break;
+                case MEDIAN:
+                    entry = this->get_median_entry();
+                    break;
+                default:
+                    break;
+            }
+        }
+        return entry;
+    }
+};
+
+namespace util {
+/* a class that represents an entry in the Dijkstra expansion priority queue */
+class PQ_Entry {
+  public:
+    int rr_node_ind; //index in device_ctx.rr_nodes that this entry represents
+    float cost;      //the cost of the path to get to this node
+
+    /* store backward delay, R and congestion info */
+    float delay;
+    float R_upstream;
+    float congestion_upstream;
+
+    PQ_Entry(int set_rr_node_ind, int /*switch_ind*/, float parent_delay, float parent_R_upstream, float parent_congestion_upstream, bool starting_node);
+
+    bool operator<(const PQ_Entry& obj) const {
+        /* inserted into max priority queue so want queue entries with a lower cost to be greater */
+        return (this->cost > obj.cost);
+    }
+};
+} // namespace util
+
+void expand_dijkstra_neighbours(util::PQ_Entry parent_entry,
+                                std::vector<float>& node_visited_costs,
+                                std::vector<bool>& node_expanded,
+                                std::priority_queue<util::PQ_Entry>& pq);
+
+#endif

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -32,6 +32,7 @@
 #include "rr_graph_writer.h"
 #include "rr_graph_reader.h"
 #include "router_lookahead_map.h"
+#include "connection_box_lookahead_map.h"
 #include "rr_graph_clock.h"
 
 #include "rr_types.h"

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -131,7 +131,7 @@ void load_rr_file(const t_graph_type graph_type,
         t_chan_width nodes_per_chan;
         process_channels(nodes_per_chan, grid, next_component, loc_data);
 
-        next_component = get_first_child(rr_graph, "connection_boxes", loc_data, OPTIONAL);
+        next_component = get_first_child(rr_graph, "connection_boxes", loc_data, pugiutil::OPTIONAL);
         if (next_component != nullptr) {
             process_connection_boxes(next_component, loc_data);
         } else {
@@ -315,7 +315,7 @@ void process_nodes(pugi::xml_node parent, const pugiutil::loc_data& loc_data) {
         } else if (strcmp(node_type, "IPIN") == 0) {
             node.set_type(IPIN);
 
-            pugi::xml_node connection_boxSubnode = get_single_child(rr_node, "connection_box", loc_data, OPTIONAL);
+            pugi::xml_node connection_boxSubnode = get_single_child(rr_node, "connection_box", loc_data, pugiutil::OPTIONAL);
             if (connection_boxSubnode) {
                 int x = get_attribute(connection_boxSubnode, "x", loc_data).as_int();
                 int y = get_attribute(connection_boxSubnode, "y", loc_data).as_int();
@@ -345,7 +345,7 @@ void process_nodes(pugi::xml_node parent, const pugiutil::loc_data& loc_data) {
             }
         }
 
-        pugi::xml_node connection_boxSubnode = get_single_child(rr_node, "canonical_loc", loc_data, OPTIONAL);
+        pugi::xml_node connection_boxSubnode = get_single_child(rr_node, "canonical_loc", loc_data, pugiutil::OPTIONAL);
         if (connection_boxSubnode) {
             int x = get_attribute(connection_boxSubnode, "x", loc_data).as_int();
             int y = get_attribute(connection_boxSubnode, "y", loc_data).as_int();

--- a/vpr/src/route/rr_node.h
+++ b/vpr/src/route/rr_node.h
@@ -173,7 +173,7 @@ class t_rr_node {
     t_edge_size edges_capacity_ = 0;
     uint8_t num_non_configurable_edges_ = 0;
 
-    int8_t cost_index_ = -1;
+    uint16_t cost_index_ = -1;
     int16_t rc_index_ = -1;
 
     int16_t xlow_ = -1;

--- a/vpr/test/test_place_delay_model_serdes.cpp
+++ b/vpr/test/test_place_delay_model_serdes.cpp
@@ -1,0 +1,87 @@
+#include "catch.hpp"
+
+#include "place_delay_model.h"
+
+namespace {
+
+#ifdef VTR_ENABLE_CAPNPROTO
+static constexpr const char kDeltaDelayBin[] = "test_delta_delay.bin";
+static constexpr const char kOverrideDelayBin[] = "test_override_delay.bin";
+
+TEST_CASE("round_trip_delta_delay_model", "[vpr]") {
+    constexpr size_t kDimX = 10;
+    constexpr size_t kDimY = 10;
+    vtr::Matrix<float> delays;
+    delays.resize({kDimX, kDimY});
+
+    for (size_t x = 0; x < kDimX; ++x) {
+        for (size_t y = 0; y < kDimY; ++y) {
+            delays[x][y] = (x + 1) * (y + 1);
+        }
+    }
+    DeltaDelayModel model(std::move(delays));
+    const auto& delays1 = model.delays();
+
+    model.write(kDeltaDelayBin);
+
+    DeltaDelayModel model2;
+    model2.read(kDeltaDelayBin);
+
+    const auto& delays2 = model2.delays();
+
+    REQUIRE(delays1.size() == delays2.size());
+    REQUIRE(delays1.ndims() == delays2.ndims());
+    for (size_t dim = 0; dim < delays1.ndims(); ++dim) {
+        REQUIRE(delays1.dim_size(dim) == delays2.dim_size(dim));
+    }
+
+    for (size_t x = 0; x < kDimX; ++x) {
+        for (size_t y = 0; y < kDimY; ++y) {
+            CHECK(delays1[x][y] == delays2[x][y]);
+        }
+    }
+}
+
+TEST_CASE("round_trip_override_delay_model", "[vpr]") {
+    constexpr size_t kDimX = 10;
+    constexpr size_t kDimY = 10;
+    vtr::Matrix<float> delays;
+    delays.resize({kDimX, kDimY});
+
+    for (size_t x = 0; x < kDimX; ++x) {
+        for (size_t y = 0; y < kDimY; ++y) {
+            delays[x][y] = (x + 1) * (y + 1);
+        }
+    }
+    OverrideDelayModel model;
+    auto base_model = std::make_unique<DeltaDelayModel>(delays);
+    model.set_base_delay_model(std::move(base_model));
+    model.set_delay_override(1, 2, 3, 4, 5, 6, -1);
+    model.set_delay_override(2, 2, 3, 4, 5, 6, -2);
+
+    model.write(kOverrideDelayBin);
+
+    OverrideDelayModel model2;
+    model2.read(kOverrideDelayBin);
+
+    const auto& delays1 = model.base_delay_model()->delays();
+    const auto& delays2 = model2.base_delay_model()->delays();
+
+    REQUIRE(delays1.size() == delays2.size());
+    REQUIRE(delays1.ndims() == delays2.ndims());
+    for (size_t dim = 0; dim < delays1.ndims(); ++dim) {
+        REQUIRE(delays1.dim_size(dim) == delays2.dim_size(dim));
+    }
+
+    for (size_t x = 0; x < kDimX; ++x) {
+        for (size_t y = 0; y < kDimY; ++y) {
+            CHECK(delays1[x][y] == delays2[x][y]);
+        }
+    }
+
+    CHECK(model2.get_delay_override(1, 2, 3, 4, 5, 6) == -1);
+    CHECK(model2.get_delay_override(2, 2, 3, 4, 5, 6) == -2);
+}
+#endif
+
+} // namespace


### PR DESCRIPTION
#### Description
Replace ad-hoc fixed sampling method with a map from segment type to an rr_node near the center of the grid.

TODO fill out the rest of this.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
