### PR TITLE
add --quick_check_route, disables slow non-configurable edge check

### DIFF
--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -354,6 +354,7 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
     RouterOpts->write_router_lookahead = Options.write_router_lookahead;
     RouterOpts->read_router_lookahead = Options.read_router_lookahead;
     RouterOpts->disable_check_route = Options.disable_check_route;
+    RouterOpts->quick_check_route = Options.quick_check_route;
 }
 
 static void SetupAnnealSched(const t_options& Options,

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1602,6 +1602,11 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("off")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    route_timing_grp.add_argument<bool, ParseOnOff>(args.quick_check_route, "--quick_check_route")
+        .help("Runs check_route, disabling slow checks, once routing step has finished or when routing file is loaded")
+        .default_value("off")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     route_timing_grp.add_argument(args.router_debug_net, "--router_debug_net")
         .help(
             "Controls when router debugging is enabled.\n"

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -132,6 +132,7 @@ struct t_options {
     argparse::ArgValue<e_router_algorithm> RouterAlgorithm;
     argparse::ArgValue<int> min_incremental_reroute_fanout;
     argparse::ArgValue<bool> disable_check_route;
+    argparse::ArgValue<bool> quick_check_route;
 
     /* Timing-driven router options only */
     argparse::ArgValue<float> astar_fac;

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -675,7 +675,7 @@ RouteStatus vpr_route_flow(t_vpr_setup& vpr_setup, const t_arch& arch) {
         if (route_status.success()) {
             //Sanity check the routing
             if (!router_opts.disable_check_route) {
-                check_route(router_opts.route_type);
+                check_route(router_opts.route_type, router_opts.quick_check_route);
             }
             get_serial_num();
 

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -943,6 +943,7 @@ struct t_router_opts {
     std::string write_router_lookahead;
     std::string read_router_lookahead;
     bool disable_check_route;
+    bool quick_check_route;
 };
 
 struct t_analysis_opts {

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -3,6 +3,7 @@
 #include "vtr_assert.h"
 #include "vtr_log.h"
 #include "vtr_memory.h"
+#include "vtr_time.h"
 
 #include "vpr_types.h"
 #include "vpr_error.h"
@@ -630,18 +631,13 @@ static void check_node_and_range(int inode, enum e_route_type route_type) {
 //Checks that all non-configurable edges are in a legal configuration
 //This check is slow, so it has been moved out of check_route()
 static void check_all_non_configurable_edges() {
-    VTR_LOG("\n");
-    VTR_LOG("Checking to ensure non-configurable edges are legal...\n");
-
+    vtr::ScopedStartFinishTimer timer("Checking to ensure non-configurable edges are legal");
     auto non_configurable_rr_sets = identify_non_configurable_rr_sets();
-
     auto& cluster_ctx = g_vpr_ctx.clustering();
+
     for (auto net_id : cluster_ctx.clb_nlist.nets()) {
         check_non_configurable_edges(net_id, non_configurable_rr_sets);
     }
-
-    VTR_LOG("Completed non-configurable edge check successfully.\n");
-    VTR_LOG("\n");
 }
 
 //Checks that the specified routing is legal with respect to non-configurable edges

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -25,11 +25,12 @@ static void reset_flags(ClusterNetId inet, bool* connected_to_route);
 static void check_locally_used_clb_opins(const t_clb_opins_used& clb_opins_used_locally,
                                          enum e_route_type route_type);
 
+static void check_all_non_configurable_edges();
 static bool check_non_configurable_edges(ClusterNetId net, const t_non_configurable_rr_sets& non_configurable_rr_sets);
 
 /************************ Subroutine definitions ****************************/
 
-void check_route(enum e_route_type route_type) {
+void check_route(enum e_route_type route_type, bool quick) {
     /* This routine checks that a routing:  (1) Describes a properly         *
      * connected path for each net, (2) this path connects all the           *
      * pins spanned by that net, and (3) that no routing resources are       *
@@ -64,8 +65,6 @@ void check_route(enum e_route_type route_type) {
     }
 
     check_locally_used_clb_opins(route_ctx.clb_opins_used_locally, route_type);
-
-    auto non_configurable_rr_sets = identify_non_configurable_rr_sets();
 
     connected_to_route = (bool*)vtr::calloc(device_ctx.rr_nodes.size(), sizeof(bool));
 
@@ -153,14 +152,17 @@ void check_route(enum e_route_type route_type) {
             }
         }
 
-        check_non_configurable_edges(net_id, non_configurable_rr_sets);
-
         reset_flags(net_id, connected_to_route);
 
     } /* End for each net */
 
     free(pin_done);
     free(connected_to_route);
+
+    if (!quick) {
+        check_all_non_configurable_edges();
+    }
+
     VTR_LOG("Completed routing consistency check successfully.\n");
     VTR_LOG("\n");
 }
@@ -623,6 +625,23 @@ static void check_node_and_range(int inode, enum e_route_type route_type) {
                         "in check_node_and_range: rr_node #%d is out of legal, range (0 to %d).\n", inode, device_ctx.rr_nodes.size() - 1);
     }
     check_rr_node(inode, route_type, device_ctx);
+}
+
+//Checks that all non-configurable edges are in a legal configuration
+//This check is slow, so it has been moved out of check_route()
+static void check_all_non_configurable_edges() {
+    VTR_LOG("\n");
+    VTR_LOG("Checking to ensure non-configurable edges are legal...\n");
+
+    auto non_configurable_rr_sets = identify_non_configurable_rr_sets();
+
+    auto& cluster_ctx = g_vpr_ctx.clustering();
+    for (auto net_id : cluster_ctx.clb_nlist.nets()) {
+        check_non_configurable_edges(net_id, non_configurable_rr_sets);
+    }
+
+    VTR_LOG("Completed non-configurable edge check successfully.\n");
+    VTR_LOG("\n");
 }
 
 //Checks that the specified routing is legal with respect to non-configurable edges

--- a/vpr/src/route/check_route.h
+++ b/vpr/src/route/check_route.h
@@ -3,7 +3,7 @@
 #include "physical_types.h"
 #include "route_common.h"
 
-void check_route(enum e_route_type route_type);
+void check_route(enum e_route_type route_type, bool quick);
 
 void recompute_occupancy_from_scratch();
 


### PR DESCRIPTION
This flag allows disabling the slow non-configurable edge check, so that just the quick routing checks can be enabled.

https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/537