### PR TITLE
Remove cached segment map from connection map lookahead file.

### DIFF
--- a/libs/libvtrcapnproto/connection_map.capnp
+++ b/libs/libvtrcapnproto/connection_map.capnp
@@ -20,6 +20,5 @@ struct VprFloatEntry {
 struct VprCostMap {
     costMap @0 :Matrix.Matrix((Matrix.Matrix(VprCostEntry)));
     offset @1 :Matrix.Matrix(VprVector2D);
-    segmentMap @2 :List(Int64);
-    penalty @3 :Matrix.Matrix(VprFloatEntry);
+    penalty @2 :Matrix.Matrix(VprFloatEntry);
 }

--- a/vpr/src/route/connection_box_lookahead_map.cpp
+++ b/vpr/src/route/connection_box_lookahead_map.cpp
@@ -109,17 +109,8 @@ static vtr::Point<T> closest_point_in_rect(const vtr::Rect<T>& r, const vtr::Poi
     }
 }
 
-// resize internal data structures
-void CostMap::set_counts(size_t seg_count, size_t box_count) {
-    cost_map_.clear();
-    offset_.clear();
-    penalty_.clear();
-    cost_map_.resize({seg_count, box_count});
-    offset_.resize({seg_count, box_count});
-    penalty_.resize({seg_count, box_count});
-    seg_count_ = seg_count;
-    box_count_ = box_count;
-
+// build the segment map
+void CostMap::build_segment_map() {
     const auto& device_ctx = g_vpr_ctx.device();
     segment_map_.resize(device_ctx.rr_nodes.size());
     for (size_t i = 0; i < segment_map_.size(); ++i) {
@@ -130,6 +121,18 @@ void CostMap::set_counts(size_t seg_count, size_t box_count) {
 
         segment_map_[i] = from_seg_index;
     }
+}
+
+// resize internal data structures
+void CostMap::set_counts(size_t seg_count, size_t box_count) {
+    cost_map_.clear();
+    offset_.clear();
+    penalty_.clear();
+    cost_map_.resize({seg_count, box_count});
+    offset_.resize({seg_count, box_count});
+    penalty_.resize({seg_count, box_count});
+    seg_count_ = seg_count;
+    box_count_ = box_count;
 }
 
 // cached node -> segment map
@@ -637,6 +640,7 @@ void ConnectionBoxMapLookahead::compute(const std::vector<t_segment_inf>& segmen
     auto& device_ctx = g_vpr_ctx.device();
     cost_map_.set_counts(segment_inf.size(),
                          device_ctx.connection_boxes.num_connection_box_types());
+    cost_map_.build_segment_map();
 
     VTR_ASSERT(REPRESENTATIVE_ENTRY_METHOD == util::SMALLEST);
     RoutingCosts all_delay_costs;
@@ -1052,6 +1056,7 @@ static void FromFloat(VprFloatEntry::Builder* out, const float& in) {
 }
 
 void CostMap::read(const std::string& file) {
+    build_segment_map();
     MmapFile f(file);
 
     /* Increase reader limit to 1G words. */
@@ -1060,16 +1065,6 @@ void CostMap::read(const std::string& file) {
     ::capnp::FlatArrayMessageReader reader(f.getData(), opts);
 
     auto cost_map = reader.getRoot<VprCostMap>();
-
-    {
-        const auto& segment_map = cost_map.getSegmentMap();
-        segment_map_.resize(segment_map.size());
-        auto dst_iter = segment_map_.begin();
-        for (const auto& src : segment_map) {
-            *dst_iter++ = src;
-        }
-    }
-
     {
         const auto& offset = cost_map.getOffset();
         ToNdMatrix<2, VprVector2D, std::pair<int, int>>(
@@ -1093,13 +1088,6 @@ void CostMap::write(const std::string& file) const {
     ::capnp::MallocMessageBuilder builder;
 
     auto cost_map = builder.initRoot<VprCostMap>();
-
-    {
-        auto segment_map = cost_map.initSegmentMap(segment_map_.size());
-        for (size_t i = 0; i < segment_map_.size(); ++i) {
-            segment_map.set(i, segment_map_[i]);
-        }
-    }
 
     {
         auto offset = cost_map.initOffset();

--- a/vpr/src/route/connection_box_lookahead_map.h
+++ b/vpr/src/route/connection_box_lookahead_map.h
@@ -50,6 +50,7 @@ typedef std::unordered_map<RoutingCostKey, float, HashRoutingCostKey> RoutingCos
 class CostMap {
   public:
     void set_counts(size_t seg_count, size_t box_count);
+    void build_segment_map();
     int node_to_segment(int from_node_ind) const;
     util::Cost_Entry find_cost(int from_seg_index, ConnectionBoxId box_id, int delta_x, int delta_y) const;
     void set_cost_map(const RoutingCosts& delay_costs, const RoutingCosts& base_costs);


### PR DESCRIPTION
Recomputing the stored segment map takes 0.01 second on my machine for the full 50T graph, and this makes it difficult to reorder node IDs.