### PR TITLE
[DNM] Lookahead analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(VTR_ENABLE_SANITIZE "Enable address/leak/undefined-behaviour sanitizers (
 option(VTR_ENABLE_PROFILING "Enable performance profiler (gprof)" OFF)
 option(VTR_ENABLE_COVERAGE "Enable code coverage tracking (gcov)" OFF)
 option(VTR_ENABLE_DEBUG_LOGGING "Enable debug logging" OFF)
+option(VTR_ENABLE_COST_MAP_DUPLICATION_ANALYSIS "Enable cost map duplication analysis. Analysis is ran during lookahead generation and results are saved to file: <architecture>_duplicated_cost_map_blocks.log" OFF)
 
 #Allow the user to decide weather to compile the graphics library
 set(VPR_USE_EZGL "auto" CACHE STRING "Specify whether vpr uses the graphics library")
@@ -236,6 +237,16 @@ if(VTR_ENABLE_PROFILING)
     #Enable gprof
     set(PROFILING_FLAGS "-g -pg")
     message(STATUS "Profiling Flags: ${PROFILING_FLAGS}")
+endif()
+
+#
+# Analysis of duplicated cost maps
+#
+
+if(VTR_ENABLE_COST_MAP_DUPLICATION_ANALYSIS)
+    #Enable ANALYZE_COST_MAP_DUPLICATION
+    add_compile_definitions(ANALYZE_COST_MAP_DUPLICATION)
+    message(STATUS "Analysis of duplicated cost maps: enabled")
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,8 +244,8 @@ endif()
 #
 
 if(VTR_ENABLE_COST_MAP_DUPLICATION_ANALYSIS)
-    #Enable ANALYZE_COST_MAP_DUPLICATION
-    add_compile_definitions(ANALYZE_COST_MAP_DUPLICATION)
+    #Enable VPR_ANALYZE_COST_MAP_DUPLICATION
+    add_compile_definitions(VPR_ANALYZE_COST_MAP_DUPLICATION)
     message(STATUS "Analysis of duplicated cost maps: enabled")
 endif()
 

--- a/vpr/src/route/connection_box_lookahead_map.cpp
+++ b/vpr/src/route/connection_box_lookahead_map.cpp
@@ -775,7 +775,6 @@ void ConnectionBoxMapLookahead::compute(const std::vector<t_segment_inf>& segmen
             }
             if (is_const_block && total_path_count > 0) {
                 if (const_maps[toFind].find(base_key) == const_maps[toFind].end()) {
-                    std::cout<<toFind<<std::endl;
                     std::map<std::string, RoutingCosts> base_map = {{base_key, base_costs}};
                     const_maps.insert({toFind, base_map});
                 }

--- a/vpr/src/route/connection_box_lookahead_map.cpp
+++ b/vpr/src/route/connection_box_lookahead_map.cpp
@@ -42,8 +42,6 @@
 
 #define CONNECTION_BOX_LOOKAHEAD_MAP_PRINT_COST_MAPS
 
-//#define ANALYZE_COST_MAP_DUPLICATION
-
 // Sample based an NxN grid of starting segments, where N = SAMPLE_GRID_SIZE
 static constexpr int SAMPLE_GRID_SIZE = 3;
 

--- a/vpr/src/route/connection_box_lookahead_map.cpp
+++ b/vpr/src/route/connection_box_lookahead_map.cpp
@@ -29,7 +29,7 @@
 #    include <tbb/mutex.h>
 #endif
 
-#if defined(ANALYZE_COST_MAP_DUPLICATION)
+#if defined(VPR_ANALYZE_COST_MAP_DUPLICATION)
 #    include <fstream>
 #endif
 
@@ -657,11 +657,12 @@ void ConnectionBoxMapLookahead::compute(const std::vector<t_segment_inf>& segmen
     RoutingCosts all_delay_costs;
     RoutingCosts all_base_costs;
 
-#if defined(ANALYZE_COST_MAP_DUPLICATION)
+#if defined(VPR_ANALYZE_COST_MAP_DUPLICATION)
     std::map<std::string, std::vector<RoutingCosts>> all_mapped_delay_costs;
     std::map<std::string, std::vector<RoutingCosts>> all_mapped_base_costs;
     std::vector<std::string> const_blocks = {"NO_MAP_COPY"};
 #else
+    // FIXME: TODO: These segment names are hard-coded just for testing purposes
     std::vector<std::string> const_blocks = {"BYP_L", "FAN_L", "INPINFEED"};
 #endif
     const std::string delay_key = "DELAY";
@@ -760,7 +761,7 @@ void ConnectionBoxMapLookahead::compute(const std::vector<t_segment_inf>& segmen
                 VTR_LOG_WARN("No paths found for sample region %s(%d, %d)\n",
                              segment_inf[region.segment_type].name.c_str(), region.grid_location.x(), region.grid_location.y());
             }
-#if defined(ANALYZE_COST_MAP_DUPLICATION)
+#if defined(VPR_ANALYZE_COST_MAP_DUPLICATION)
             else {
                 if (all_mapped_delay_costs.find(toFind) == all_mapped_delay_costs.end()) {
                     std::vector<RoutingCosts> temp;
@@ -819,7 +820,7 @@ void ConnectionBoxMapLookahead::compute(const std::vector<t_segment_inf>& segmen
     }
 #endif
 
-#if defined(ANALYZE_COST_MAP_DUPLICATION)
+#if defined(VPR_ANALYZE_COST_MAP_DUPLICATION)
     std::vector<std::string> const_block_candidates;
     std::vector<std::string> const_blocks_names;
 


### PR DESCRIPTION
This PR contains two not yet fully complete features:
 - **Router lookahead analysis:** 
  Computes the lookahead normally, once done compares the computed maps and identifies segments for which these maps do not differ across regions. Names of these segments are written to a file. The analysis has to be enabled on the compilation time
 - **Avoidance of duplicate lookahead computation**
  Given a list of segment names the patched code computes the delay map only once and then automatically duplicates it among other regions with matching segment types. For the full 50T graph this yields in **4.5%** less computation time. For the testing purposes, names of the segments are hard-coded.

I'm opening this PR to discuss how to progress with these features since the solution is promising. Some random ideas:
 - Mark segments in `arch.xml` that they have identical route lookahead map across all regions.
 - Make run-time switchable "analysis run" and "full computation run". This way the special segments could be first identified and they names written to a file, then used in subsequently.