### PR TITLE
router_lookahead: fix base cost function call

### DIFF
--- a/vpr/src/route/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead_map_utils.cpp
@@ -38,7 +38,7 @@ PQ_Entry::PQ_Entry(
 
         float base_cost = 0.f;
         if (device_ctx.rr_switch_inf[switch_ind].configurable()) {
-            base_cost = get_rr_cong_cost(set_rr_node_ind);
+            base_cost = get_single_rr_cong_base_cost(set_rr_node_ind);
         }
 
         VTR_ASSERT(T_linear >= 0.);
@@ -92,7 +92,7 @@ util::PQ_Entry_Base_Cost::PQ_Entry_Base_Cost(
 
     if (parent != nullptr) {
         if (device_ctx.rr_switch_inf[switch_ind].configurable()) {
-            this->base_cost = parent->base_cost + get_rr_cong_cost(set_rr_node_ind);
+            this->base_cost = parent->base_cost + get_single_rr_cong_base_cost(set_rr_node_ind);
         } else {
             this->base_cost = parent->base_cost;
         }


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

I have updated and rebased the wip/lookahead_sampling2 to the current master.
There is an issue with the base_cost calculation as the function to get the congestion cost has changed and has been split in different functions.

During the lookahead computation, the base costs are now using the correct function that retrieves the base cost for a specific switch without the need of extra information such as the pres_fac.